### PR TITLE
Add config options to node_env variable

### DIFF
--- a/modules/aws_ecs_ec2/variables.tf
+++ b/modules/aws_ecs_ec2/variables.tf
@@ -7,7 +7,7 @@ variable "aws_region" {
 variable "node_env" {
   type        = string
   default     = "production"
-  description = "Value for NODE_ENV variable. Defaults to `production` and must be either `production`, `staging`, or `development`."
+  description = "Value for NODE_ENV variable. Defaults to `production` and should not be set to any other value, regardless of environment."
 }
 
 variable "vpc_id" {

--- a/modules/aws_ecs_ec2/variables.tf
+++ b/modules/aws_ecs_ec2/variables.tf
@@ -7,7 +7,7 @@ variable "aws_region" {
 variable "node_env" {
   type        = string
   default     = "production"
-  description = "Value for NODE_ENV variable. Defaults to `production`."
+  description = "Value for NODE_ENV variable. Defaults to `production` and must be either `production`, `staging`, or `development`."
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
@kentwalters and I recently helped Forge (fka SharesPost) debug their new ECS deployment. They kept seeing a 503 error in the browser when spinning up Retool, and when we looked at their docker logs, we saw that the `config` object was undefined. This happened because they set their `NODE_ENV = "non-prod"`. 

This comment should guide customers toward only using a permissible variable like `development`, `staging`, or `production`.