### PR TITLE
Update README.md for aws_ecs_ec2 module

### DIFF
--- a/modules/aws_ecs_ec2/README.md
+++ b/modules/aws_ecs_ec2/README.md
@@ -15,7 +15,7 @@ module "retool" {
         "<your-subnet-1>",
         "<your-subnet-2>"
     ]
-    ssh_key_pair = "<your-key-pair>"
+    ssh_key_name = "<your-key-pair>"
     ecs_retool_image = "<desired-retool-version>"
 
     # Additional configuration


### PR DESCRIPTION
Fix typo:

- `ssh_key_pair` is incorrect `ssh_key_name` is the valid variable defined.