### PR TITLE
Adv/patch/update versions ec2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@ This repository contains example Terraform modules for installing and configurin
 Disclaimer: Please use these modules only if you're comfortable configuring Terraform.
 
 # Prerequisites
-- All modules utilize **Hashicorp Terraform 3.50.0**
+
+- All modules have been test on **Hashicorp Terraform v1.3.7**
+- The AWS Provider version is set to **v4.0**
 
 # Usage
+
 Navigate to your desired cloud provider + deployment module for specific configuration options.

--- a/modules/aws_ec2_standalone/README.md
+++ b/modules/aws_ec2_standalone/README.md
@@ -63,7 +63,7 @@ docker-ps
 
 9. Add any additional configuration needed. You can refer to our documentation for [all additional environment variables](https://docs.retool.com/docs/environment-variables).
 
-10. Access your Retool instance on the ec2_public_dns that is given via the resource creation outputs. If no SSL certificate has been configured you need to access the instance on port 300 (append :300 to the end of the URL) and via http.
+10. Access your Retool instance on the ec2_public_dns that is given via the resource creation outputs. If no SSL certificate has been configured you need to access the instance on port 3000 (append :3000 to the end of the URL) and via http.
 
 ### Security Group
 

--- a/modules/aws_ec2_standalone/README.md
+++ b/modules/aws_ec2_standalone/README.md
@@ -1,8 +1,9 @@
 # AWS EC2 Standalone Deployment
 
 ## Requirements
+
 - RDS instance with port, host, username, and password
-- VPC with desired subnets 
+- VPC with desired subnets
 
 ## Usage
 
@@ -56,10 +57,13 @@ docker-ps
 ```
 
 8. Modify your environment variables. If you have an external RDS database (strongly recommended), replace the `POSTGRES_` environment variables with the new ones.
-  - If testing out your instance for the first time without SSL/HTTPS, you should uncomment `# COOKIE_INSECURE = true`
-  - Replace your `LICENSE_KEY` with your provided Retool license key
+
+- If testing out your instance for the first time without SSL/HTTPS, you should uncomment `# COOKIE_INSECURE = true`
+- Replace your `LICENSE_KEY` with your provided Retool license key
 
 9. Add any additional configuration needed. You can refer to our documentation for [all additional environment variables](https://docs.retool.com/docs/environment-variables).
+
+10. Access your Retool instance on the ec2_public_dns that is given via the resource creation outputs. If no SSL certificate has been configured you need to access the instance on port 300 (append :300 to the end of the URL) and via http.
 
 ### Security Group
 
@@ -112,5 +116,4 @@ egress_rules = [
 ]
 ```
 
-By default, this module creates a publicly-accessible security group that enables inbound traffic on ports (`30`, `443`, `22`, and `8000`) and all outbound traffic.
-
+By default, this module creates a publicly-accessible security group that enables inbound traffic on ports (`30`, `443`, `22`, and `3000`) and all outbound traffic.

--- a/modules/aws_ec2_standalone/main.tf
+++ b/modules/aws_ec2_standalone/main.tf
@@ -2,13 +2,30 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.50.0"
+      version = "~> 4.0"
     }
   }
 }
 
 provider "aws" {
   region = var.aws_region
+}
+
+data "aws_ami" "this" {
+  most_recent = true # get the latest version
+   filter {
+      name   = "name"
+      values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+      name   = "virtualization-type"
+      values = ["hvm"]
+  }
+
+  owners = [
+    "amazon" # only official images
+  ]
 }
 
 resource "aws_security_group" "this" {
@@ -45,7 +62,7 @@ resource "aws_security_group" "this" {
 }
 
 resource "aws_instance" "this" {
-  ami           = var.instance_ami
+  ami           = data.aws_ami.this.id
   instance_type = var.instance_type
   key_name      = var.ssh_key_name
 

--- a/modules/aws_ec2_standalone/variables.tf
+++ b/modules/aws_ec2_standalone/variables.tf
@@ -34,12 +34,6 @@ variable "subnet_id" {
   description = "VPC Subnet ID to launch in."
 }
 
-# variable "instance_ami" {
-#   type        = string
-#   default     = "ami-06bb3ee01d992f30d" # Ubuntu Server 22.04 LTS 64-bit x86
-#   description = "AMI for EC2 instance. Defaults to `ami-06bb3ee01d992f30d` (Ubuntu Server 22.04 LTS 64-bit x86)."
-# }
-
 variable "ssh_key_name" {
   type        = string
   description = "EC2 SSH keypair"

--- a/modules/aws_ec2_standalone/variables.tf
+++ b/modules/aws_ec2_standalone/variables.tf
@@ -18,8 +18,8 @@ variable "instance_name" {
 
 variable "version_number" {
   type        = string
-  default     = "2.96.2"
-  description = "Retool version number. Defaults to `2.96.2`."
+  default     = "2.106.2"
+  description = "Retool version number. Defaults to `2.106.2`."
 }
 
 variable "vpc_id" {
@@ -34,11 +34,11 @@ variable "subnet_id" {
   description = "VPC Subnet ID to launch in."
 }
 
-variable "instance_ami" {
-  type        = string
-  default     = "ami-00399ec92321828f5" # Ubuntu Server 20.04 LTS 64-bit x86
-  description = "AMI for EC2 instance. Defaults to `ami-00399ec92321828f5` (Ubuntu Server 20.04 LTS 64-bit x86)."
-}
+# variable "instance_ami" {
+#   type        = string
+#   default     = "ami-06bb3ee01d992f30d" # Ubuntu Server 22.04 LTS 64-bit x86
+#   description = "AMI for EC2 instance. Defaults to `ami-06bb3ee01d992f30d` (Ubuntu Server 22.04 LTS 64-bit x86)."
+# }
 
 variable "ssh_key_name" {
   type        = string

--- a/modules/aws_ecs_ec2/README.md
+++ b/modules/aws_ecs_ec2/README.md
@@ -3,6 +3,7 @@
 This module deploys an ECS cluster with autoscaling group of EC2 instances.
 
 # Usage
+
 1. Directly use our module in your existing Terraform configuration and provide the required variables
 
 ```
@@ -45,12 +46,12 @@ module "retool" {
 To configure the EC instance size, set the `instance_type` input variable (e.g. `t2.large`).
 
 **RDS Instance Class**
-To configure the RDS instance class, set the `instance_class` input variable (e.g. `db.m4.large`).
+To configure the RDS instance class, set the `instance_class` input variable (e.g. `db.m6g.large`).
 
 ## Advanced Configuration
 
-
 ### Security Groups
+
 To customize the ingress and egress rules on the security groups, you can override specific input variable defaults.
 
 - `ec2_ingress_rules` controls the inbound rules for EC2 instances in the autoscaling group
@@ -99,6 +100,7 @@ ec2_egress_rules = [
 ```
 
 ### Environment Variables
+
 To add additional [Retool environment variables](https://docs.retool.com/docs/environment-variables) to your deployment, populate the `additional_env_vars` input variable into the module.
 
 NOTE: The `additional_env_vars` will only work as type `map(string)`. Convert all booleans and numbers into strings, e.g.

--- a/modules/aws_ecs_ec2/main.tf
+++ b/modules/aws_ecs_ec2/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.50.0"
+      version = "~> 4.0"
     }
   }
 }
@@ -144,12 +144,12 @@ resource "aws_cloudwatch_log_group" "this" {
 }
 
 resource "aws_db_instance" "this" {
-  identifier                   = "${var.deployment_name}-rds-instance"
+  identifier                    = "${var.deployment_name}-rds-instance"
   allocated_storage            = 80
   instance_class               = var.rds_instance_class
   engine                       = "postgres"
-  engine_version               = "10.6"
-  name                         = "hammerhead_production"
+  engine_version               = "13.7"
+  db_name                      = "hammerhead_production"
   username                     = aws_secretsmanager_secret_version.rds_username.secret_string
   password                     = aws_secretsmanager_secret_version.rds_password.secret_string
   port                         = 5432
@@ -158,7 +158,7 @@ resource "aws_db_instance" "this" {
   performance_insights_enabled = var.rds_performance_insights_enabled
   
   skip_final_snapshot          = true
-  apply_immediately            = true
+  apply_immediately           = true
 }
 
 resource "aws_ecs_service" "retool" {
@@ -184,7 +184,7 @@ resource "aws_ecs_service" "jobs_runner" {
   task_definition = aws_ecs_task_definition.retool_jobs_runner.arn
 }
 resource "aws_ecs_task_definition" "retool_jobs_runner" {
-  family        = "retool"
+  family        = "retool-jobs-runner"
   task_role_arn = aws_iam_role.task_role.arn
   container_definitions = jsonencode(
     [

--- a/modules/aws_ecs_ec2/outputs.tf
+++ b/modules/aws_ecs_ec2/outputs.tf
@@ -39,6 +39,6 @@ output "rds_instance_arn" {
 }
 
 output "rds_instance_name" {
-  value       = aws_db_instance.this.name
+  value       = aws_db_instance.this.db_name
   description = "Name of RDS instance"
 }

--- a/modules/aws_ecs_ec2/variables.tf
+++ b/modules/aws_ecs_ec2/variables.tf
@@ -57,8 +57,8 @@ variable "retool_license_key" {
 
 variable "ecs_retool_image" {
   type        = string
-  description = "Container image for desired Retool version. Defaults to `2.96.2`"
-  default     = "tryretool/backend:2.96.2"
+  description = "Container image for desired Retool version. Defaults to `2.106.2`"
+  default     = "tryretool/backend:2.106.2"
 }
 
 variable "ecs_task_cpu" {
@@ -93,8 +93,8 @@ variable "rds_username" {
 
 variable "rds_instance_class" {
   type        = string
-  default     = "db.m4.large"
-  description = "Instance class for RDS. Defaults to `db.m4.large`"
+  default     = "db.m6g.large"
+  description = "Instance class for RDS. Defaults to `db.m6g.large`"
 }
 
 variable "rds_publicly_accessible" {


### PR DESCRIPTION
### EC2 Standalone
- Upgrade TF AWS module
- Upgrade EC2 AMI to automatically use latest version
- Update to latest Retool version (2.106.2)
- Update README

### ECS with EC2
- Update RDS instance type and version (from 10.6 to 13.7)
- Fix to `failed creating ECS Task Definition (retool): ClientException: Too many concurrent attempts to create a new revision of the specified family.` error. Renamed family name for 1 of the resources
- Update to TF output for db name
- Update README