### PR TITLE
update temporal image tag

### DIFF
--- a/modules/aws_ecs/temporal/variables.tf
+++ b/modules/aws_ecs/temporal/variables.tf
@@ -111,7 +111,7 @@ variable "private_dns_namespace_id" {
 
 variable "temporal_image" {
   type = string
-  default = "tryretool/one-offs:retool-temporal-1.1.2-a"
+  default = "tryretool/one-offs:retool-temporal-1.1.2"
   description = "Docker image to use for Temporal cluster."
 }
 


### PR DESCRIPTION
Validated the image changes doesn't break docker-compose or k8s so let's not use a pre-release version number.