### PR TITLE
Added support for RDS version control

### DIFF
--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -21,7 +21,8 @@ resource "aws_db_instance" "this" {
   allocated_storage            = 80
   instance_class               = var.rds_instance_class
   engine                       = "postgres"
-  engine_version               = "13.7"
+  engine_version               = var.rds_engine_version
+  auto_minor_version_upgrade   = var.rds_auto_minor_version_upgrade
   db_name                      = "hammerhead_production"
   username                     = aws_secretsmanager_secret_version.rds_username.secret_string
   password                     = aws_secretsmanager_secret_version.rds_password.secret_string

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -129,6 +129,18 @@ variable "rds_performance_insights_retention_period" {
   description = "The time in days to retain Performance Insights for RDS. Defaults to 14."
 }
 
+variable "rds_auto_minor_version_upgrade" {
+  type        = bool
+  default     = true
+  description = "Whether to enable auto minor version upgrade for RDS. Defaults to true."
+}
+
+variable "rds_engine_version" {
+  type        = string
+  default     = "13.7"
+  description = "The engine version for RDS. Defaults to 13.7."
+}
+
 variable "use_exising_temporal_cluster" {
   type        = bool
   default     = false


### PR DESCRIPTION
This is a simple PR that does two thing:

- Add support for enabling / disabling RDS [minor version upgrades](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#auto_minor_version_upgrade)

- Add support for specifying the RDS engine version itself (currently hardcoded)

The need for this is due to a few issues caused by the current hardcoded database version (13.7).

I added this module to my project last week, all was well. Today, when running `terraform plan ...` again, there is now a delta:

```
Terraform will perform the following actions:

  # module.retool.aws_db_instance.this will be updated in-place
  ~ resource "aws_db_instance" "this" {
      ~ engine_version                        = "13.10" -> "13.7"
```

In the past days, the DB hit its regularly scheduled maintenance window, and upgraded from `13.7 -> 13.10`.

However, RDS does not support downgrades, as seen when attempting to apply:

```
│ Error: updating RDS DB Instance (retool-rds-instance): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: ~, api error InvalidParameterCombination: Cannot upgrade postgres from 13.10 to 13.7
```

So as the module is now, I only have one option, and that's to login to the AWS UI and disable "Auto minor version upgrade" under Maintenance, which is of course not idempotent, and contrary to Terraform principles.

This PR fixes the issue, by providing some flexibility:

- a user can disable auto version upgrades (I intend to do this)
- a user can leave upgrades in place, and when the situation I'm in occurs, instead update the newly exposed variable `rds_engine_version` to (in this case) `13.10`

These are very minor changes, validated with:

```
aws_ecs (feature/rds-version-support) λ terraform validate
Success! The configuration is valid.
```

If possible, it'd be great to get this merged quickly, so I don't have to use the web UI / my own fork I don't intend to maintain.

Thanks!

