### PR TITLE
Specify VPC ID when creating RDS and temporal_aurora security groups

### DIFF
--- a/modules/aws_ecs/security.tf
+++ b/modules/aws_ecs/security.tf
@@ -1,6 +1,7 @@
 resource "aws_security_group" "rds" {
   name        = "${var.deployment_name}-rds-security-group"
   description = "Retool database security group"
+  vpc_id      = var.vpc_id
 
   ingress {
     description = "Retool ECS Postgres Inbound"
@@ -26,6 +27,7 @@ resource "aws_security_group" "temporal_aurora" {
   count       = var.workflows_enabled ? 1 : 0
   name        = "${var.deployment_name}-temporal-rds-security-group"
   description = "Retool database security group"
+  vpc_id      = var.vpc_id
 
   ingress {
     description = "Retool Temporal ECS Postgres Inbound"


### PR DESCRIPTION
Specify VPC ID when creating RDS and temporal_aurora security groups instead of using the default VPC.
This allows the module to be deployed to an account where no default VPC exists.