### PR TITLE
updated provider/temporal module, added ca cert var

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Disclaimer: Please use these modules only if you're comfortable configuring Terr
 # Prerequisites
 
 - All modules have been test on **Hashicorp Terraform v1.3.7**
-- The AWS Provider version is set to **v4.0**
+- The AWS Provider version is set to **v5.0**
 
 # Usage
 

--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -2,13 +2,9 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
-}
-
-provider "aws" {
-  region = var.aws_region
 }
 
 resource "aws_cloudwatch_log_group" "this" {
@@ -25,6 +21,7 @@ resource "aws_db_instance" "this" {
   identifier                    = "${var.deployment_name}-rds-instance"
   allocated_storage            = 80
   instance_class               = var.rds_instance_class
+  ca_cert_identifier           = var.rds_ca_cert_identifier
   engine                       = "postgres"
   engine_version               = "13.7"
   db_name                      = "hammerhead_production"

--- a/modules/aws_ecs/temporal/main.tf
+++ b/modules/aws_ecs/temporal/main.tf
@@ -1,6 +1,6 @@
 module "temporal_aurora_rds" {
   source  = "terraform-aws-modules/rds-aurora/aws"
-  version = "8.0.2"
+  version = "8.5.0"
 
   name="${var.deployment_name}-temporal-rds-instance"
   engine            = "aurora-postgresql"

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -129,6 +129,12 @@ variable "rds_performance_insights_retention_period" {
   description = "The time in days to retain Performance Insights for RDS. Defaults to 14."
 }
 
+variable "rds_ca_cert_identifier" {
+  type        = string
+  default     = "rds-ca-rsa2048-g1"
+  description = "The identifier of the CA certificate for the DB instance"
+}
+
 variable "use_exising_temporal_cluster" {
   type        = bool
   default     = false


### PR DESCRIPTION
updated aws provider to ~> 5, which also required an update of the temporal module.  confirmed deployment works correctly.
added a variable to allow control of which cert authority is used for rds.
removed provider block from main, per best practices.