### PR TITLE
Add RDS engine version and auto-update variables

### DIFF
--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -27,7 +27,8 @@ resource "aws_db_instance" "this" {
   instance_class               = var.rds_instance_class
   ca_cert_identifier           = var.rds_ca_cert_identifier
   engine                       = "postgres"
-  engine_version               = "13.7"
+  engine_version               = var.rds_instance_engine_version
+  auto_minor_version_upgrade   = var.rds_instance_auto_minor_version_upgrade
   db_name                      = "hammerhead_production"
   username                     = aws_secretsmanager_secret_version.rds_username.secret_string
   password                     = aws_secretsmanager_secret_version.rds_password.secret_string

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -117,6 +117,18 @@ variable "rds_instance_class" {
   description = "Instance class for RDS. Defaults to `db.m6g.large`"
 }
 
+variable "rds_instance_engine_version" {
+  type        = string
+  default     = "13.7"
+  description = "Version of the Postgres RDS instance. Defaults to 13.7"
+}
+
+variable "rds_instance_auto_minor_version_upgrade" {
+  type = bool
+  default = true
+  description = "Whether to automatically upgrade the minor version of the Postgres RDS instance. Defaults to true."
+}
+
 variable "rds_publicly_accessible" {
   type        = bool
   default     = false


### PR DESCRIPTION
This PR:
* Adds the `rds_instance_engine_version` input defaulting to the previous value for backwards compatibility
* Adds the `rds_instance_auto_minor_version_upgrade` input defaulting to the previous implicit value for backwards compatibility