### PR TITLE
Adds propagate_tags to ecs service, task role output

### DIFF
--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -427,4 +427,5 @@ module "temporal" {
   launch_type = var.launch_type
   container_sg_id = aws_security_group.containers.id
   aws_ecs_capacity_provider_name = var.launch_type == "EC2" ? aws_ecs_capacity_provider.this[0].name : null
+  task_propagate_tags = var.task_propagate_tags
 }

--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -50,7 +50,7 @@ resource "aws_ecs_service" "retool" {
   deployment_maximum_percent         = var.maximum_percent
   deployment_minimum_healthy_percent = var.minimum_healthy_percent
   iam_role                           = var.launch_type == "EC2" ? aws_iam_role.service_role.arn : null
-  propagate_tags		     = var.task_propagate_tags
+  propagate_tags                     = var.task_propagate_tags
 
   load_balancer {
     target_group_arn = aws_lb_target_group.this.arn
@@ -84,6 +84,7 @@ resource "aws_ecs_service" "jobs_runner" {
   cluster         = aws_ecs_cluster.this.id
   desired_count   = 1
   task_definition = aws_ecs_task_definition.retool_jobs_runner.arn
+  propagate_tags  = var.task_propagate_tags
 
   # Need to explictly set this in aws_ecs_service to avoid destructive behavior: https://github.com/hashicorp/terraform-provider-aws/issues/22823
   capacity_provider_strategy {
@@ -112,6 +113,7 @@ resource "aws_ecs_service" "workflows_backend" {
   cluster         = aws_ecs_cluster.this.id
   desired_count   = 1
   task_definition = aws_ecs_task_definition.retool_workflows_backend[0].arn
+  propagate_tags  = var.task_propagate_tags
 
   # Need to explictly set this in aws_ecs_service to avoid destructive behavior: https://github.com/hashicorp/terraform-provider-aws/issues/22823
   capacity_provider_strategy {
@@ -143,6 +145,7 @@ resource "aws_ecs_service" "workflows_worker" {
   cluster         = aws_ecs_cluster.this.id
   desired_count   = 1
   task_definition = aws_ecs_task_definition.retool_workflows_worker[0].arn
+  propagate_tags  = var.task_propagate_tags
 
   # Need to explictly set this in aws_ecs_service to avoid destructive behavior: https://github.com/hashicorp/terraform-provider-aws/issues/22823
   capacity_provider_strategy {

--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -50,6 +50,7 @@ resource "aws_ecs_service" "retool" {
   deployment_maximum_percent         = var.maximum_percent
   deployment_minimum_healthy_percent = var.minimum_healthy_percent
   iam_role                           = var.launch_type == "EC2" ? aws_iam_role.service_role.arn : null
+  propagate_tags		     = var.task_propagate_tags
 
   load_balancer {
     target_group_arn = aws_lb_target_group.this.arn

--- a/modules/aws_ecs/outputs.tf
+++ b/modules/aws_ecs/outputs.tf
@@ -49,11 +49,6 @@ output "target_group_arn" {
 }
 
 output "iam_task_role_arn" {
-  value	      = aws_iam_role.task_role.arn
+  value       = aws_iam_role.task_role.arn
   description = "IAM role for all ECS tasks"
-}
-
-output "iam_service_role_arn" {
-  value	      = aws_iam_role.service_role.arn
-  description = "IAM role for all ECS services"
 }

--- a/modules/aws_ecs/outputs.tf
+++ b/modules/aws_ecs/outputs.tf
@@ -47,3 +47,13 @@ output "target_group_arn" {
   value       = aws_lb_target_group.this.arn
   description = "ARN for alb target group"
 }
+
+output "iam_task_role_arn" {
+  value	      = aws_iam_role.task_role.arn
+  description = "IAM role for all ECS tasks"
+}
+
+output "iam_service_role_arn" {
+  value	      = aws_iam_role.service_role.arn
+  description = "IAM role for all ECS services"
+}

--- a/modules/aws_ecs/outputs.tf
+++ b/modules/aws_ecs/outputs.tf
@@ -50,5 +50,10 @@ output "target_group_arn" {
 
 output "iam_task_role_arn" {
   value       = aws_iam_role.task_role.arn
-  description = "IAM role for all ECS tasks"
+  description = "IAM role ARN for all ECS tasks"
+}
+
+output "iam_task_role_name" {
+  value       = aws_iam_role.task_role.name
+  description = "IAM role name for all ECS tasks"
 }

--- a/modules/aws_ecs/temporal/main.tf
+++ b/modules/aws_ecs/temporal/main.tf
@@ -67,6 +67,7 @@ resource "aws_ecs_service" "retool_temporal" {
   cluster         = var.aws_ecs_cluster_id
   desired_count   = 1
   task_definition = aws_ecs_task_definition.retool_temporal[each.key].arn
+  propagate_tags		     = var.task_propagate_tags
 
   # Need to explictly set this in aws_ecs_service to avoid destructive behavior: https://github.com/hashicorp/terraform-provider-aws/issues/22823
   capacity_provider_strategy {

--- a/modules/aws_ecs/temporal/variables.tf
+++ b/modules/aws_ecs/temporal/variables.tf
@@ -163,4 +163,9 @@ variable "aws_region" {
   description = "AWS region. Defaults to `us-east-1`"
 }
 
+variable "task_propagate_tags" {
+  type        = string
+  description = "Which resource to propagate tags from for ECS service tasks. Defaults to `TASK_DEFINITION`"
+  default     = "TASK_DEFINITION"
+}
 

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -55,6 +55,12 @@ variable "deployment_name" {
   default     = "retool"
 }
 
+variable "task_propagate_tags" {
+  type        = string
+  description = "Which resource to propagate tags from for ECS service tasks. Defaults to `TASK_DEFINITION`"
+  default     = "TASK_DEFINITION"
+}
+
 variable "retool_license_key" {
   type        = string
   description = "Retool license key"


### PR DESCRIPTION
I've got two changes bundled up here:

1. add `propagate_tags` to all `aws_ecs_service` resources, and a variable `task_propagate_tags` to control it. This allows for accurate cost tracking in AWS, as previously, the ECS tasks weren't tagged at all when run. This accounts for a large portion of the cost. 
2. add the IAM task role name and ARN as outputs. This allows for permissions to be added to tasks, such as accessing secrets manager, without directly editing the module.

![image](https://github.com/tryretool/terraform-retool-modules/assets/7509232/630dba4b-fba0-4bcc-81b2-3df2f509bd58)

![image](https://github.com/tryretool/terraform-retool-modules/assets/7509232/ab6e6ed0-06bb-4fd6-a546-a7c9098c78c5)
becomes
![image](https://github.com/tryretool/terraform-retool-modules/assets/7509232/c941aedf-b629-400e-a524-fd394820f914)
