### PR TITLE
ECS python support

### DIFF
--- a/modules/aws_ecs/locals.tf
+++ b/modules/aws_ecs/locals.tf
@@ -10,6 +10,9 @@ locals {
     },
   ]
 
+  // Use var.ecs_code_executor_image if defined, otherwise fallback to the same tag as var.ecs_retool_image
+  ecs_code_executor_image = var.ecs_code_executor_image != "" ? var.ecs_code_executor_image : format("%s:%s", "tryretool/code-executor-service", split(":", var.ecs_retool_image)[1])
+
   environment_variables = concat(
     var.additional_env_vars, # add additional environment variables
     local.base_environment_variables,

--- a/modules/aws_ecs/locals.tf
+++ b/modules/aws_ecs/locals.tf
@@ -1,12 +1,26 @@
 locals {
+  base_environment_variables = [
+    {
+      name  = "NODE_ENV"
+      value = var.node_env
+    },
+    {
+      name  = "IS_ONPREM",
+      value = "true"
+    },
+  ]
+
   environment_variables = concat(
     var.additional_env_vars, # add additional environment variables
+    local.base_environment_variables,
     local.temporal_mtls_config,
-    [
+    var.code_executor_enabled ? [
       {
-        name  = "NODE_ENV"
-        value = var.node_env
-      },
+        name  = "CODE_EXECUTOR_INGRESS_DOMAIN"
+        value = "http://code-executor.retoolsvc:3004"
+      }
+    ] : [],
+    [
       {
         name  = "FORCE_DEPLOYMENT"
         value = tostring(var.force_deployment)

--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -419,7 +419,7 @@ resource "aws_ecs_task_definition" "retool_code_executor" {
       {
         name      = "retool-code-executor"
         essential = true
-        image     = var.ecs_code_executor_image
+        image     = local.ecs_code_executor_image
         cpu       = var.launch_type == "EC2" ? var.ecs_task_resource_map["code_executor"]["cpu"] : null
         memory    = var.launch_type == "EC2" ? var.ecs_task_resource_map["code_executor"]["memory"] : null
         command = [

--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -154,6 +154,37 @@ resource "aws_ecs_service" "workflows_worker" {
   }
 }
 
+resource "aws_ecs_service" "code_executor" {
+  count           = var.code_executor_enabled ? 1 : 0
+  name            = "${var.deployment_name}-code-executor-service"
+  cluster         = aws_ecs_cluster.this.id
+  desired_count   = 1
+  task_definition = aws_ecs_task_definition.retool_code_executor[0].arn
+
+  # Need to explictly set this in aws_ecs_service to avoid destructive behavior: https://github.com/hashicorp/terraform-provider-aws/issues/22823
+  capacity_provider_strategy {
+    base              = 1
+    weight            = 100
+    capacity_provider = var.launch_type == "FARGATE" ? "FARGATE" : aws_ecs_capacity_provider.this[0].name
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.retool_code_executor_service[0].arn
+  }
+  dynamic "network_configuration" {
+
+    for_each = var.launch_type == "FARGATE" ? toset([1]) : toset([])
+
+    content {
+      subnets = var.subnet_ids
+      security_groups = [
+        aws_security_group.containers.id
+      ]
+      assign_public_ip = true
+    }
+  }
+}
+
 resource "aws_ecs_task_definition" "retool_jobs_runner" {
   family        = "retool-jobs-runner"
   task_role_arn = aws_iam_role.task_role.arn
@@ -374,6 +405,56 @@ resource "aws_ecs_task_definition" "retool_workflows_worker" {
   )
 }
 
+resource "aws_ecs_task_definition" "retool_code_executor" {
+  count         = var.code_executor_enabled ? 1 : 0
+  family        = "retool-code-executor"
+  task_role_arn = aws_iam_role.task_role.arn
+  execution_role_arn = var.launch_type == "FARGATE" ? aws_iam_role.execution_role[0].arn : null
+  requires_compatibilities = var.launch_type == "FARGATE" ?  ["FARGATE"] : null
+  network_mode  = var.launch_type == "FARGATE" ? "awsvpc" : "bridge"
+  cpu       = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["code_executor"]["cpu"] : null
+  memory    = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["code_executor"]["memory"] : null
+  container_definitions = jsonencode(
+    [
+      {
+        name      = "retool-code-executor"
+        essential = true
+        image     = var.ecs_code_executor_image
+        cpu       = var.launch_type == "EC2" ? var.ecs_task_resource_map["code_executor"]["cpu"] : null
+        memory    = var.launch_type == "EC2" ? var.ecs_task_resource_map["code_executor"]["memory"] : null
+        command = [
+          "./start.sh"
+        ]
+
+        logConfiguration = {
+          logDriver = "awslogs"
+          options = {
+            awslogs-group         = aws_cloudwatch_log_group.this.id
+            awslogs-region        = var.aws_region
+            awslogs-stream-prefix = "SERVICE_RETOOL"
+          }
+        }
+
+        health_check = {
+          command = ["CMD-SHELL", "curl http://localhost/api/checkHealth:3004 || exit 1"]
+        }
+
+        portMappings = [
+          {
+            containerPort = 3004
+            hostPort      = 3004
+            protocol      = "tcp"
+          }
+        ]
+
+        environment = concat(
+          local.base_environment_variables,
+        )
+      }
+    ]
+  )
+}
+
 resource "aws_service_discovery_private_dns_namespace" "retoolsvc" {
   count         = var.workflows_enabled ? 1 : 0
   name        = "retoolsvc"
@@ -384,6 +465,26 @@ resource "aws_service_discovery_private_dns_namespace" "retoolsvc" {
 resource "aws_service_discovery_service" "retool_workflow_backend_service" { 
   count = var.workflows_enabled ? 1 : 0
   name  = "workflow-backend"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.retoolsvc[0].id
+
+    dns_records {
+      ttl  = 60
+      type = "A"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}
+
+resource "aws_service_discovery_service" "retool_code_executor_service" {
+  count = var.code_executor_enabled ? 1 : 0
+  name  = "code-executor"
 
   dns_config {
     namespace_id = aws_service_discovery_private_dns_namespace.retoolsvc[0].id

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -57,14 +57,14 @@ variable "retool_license_key" {
 
 variable "ecs_retool_image" {
   type        = string
-  description = "Container image for desired Retool version. Defaults to `2.116.3`"
-  default     = "tryretool/backend:2.116.3"
+  description = "Container image for desired Retool version. Defaults to `3.28.7`"
+  default     = "tryretool/backend:3.28.7"
 }
 
 variable "ecs_code_executor_image" {
   type        = string
-  description = "Container image for desired code_executor version."
-  default     = "tryretool/code-executor-one-offs:3.13.0-c703e0a"
+  description = "Container image for desired code_executor version. Defaults to `3.28.7`"
+  default     = "tryretool/code-executor-service:3.28.7"
 }
 
 variable "ecs_task_resource_map" {

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -57,8 +57,14 @@ variable "retool_license_key" {
 
 variable "ecs_retool_image" {
   type        = string
-  description = "Container image for desired Retool version. Defaults to `2.106.2`"
+  description = "Container image for desired Retool version. Defaults to `2.116.3`"
   default     = "tryretool/backend:2.116.3"
+}
+
+variable "ecs_code_executor_image" {
+  type        = string
+  description = "Container image for desired code_executor version."
+  default     = "tryretool/code-executor-one-offs:3.13.0-c703e0a"
 }
 
 variable "ecs_task_resource_map" {
@@ -80,6 +86,11 @@ variable "ecs_task_resource_map" {
       memory = 4096
     }
     workflows_worker = {
+      cpu = 2048
+      memory = 4096
+    }
+
+    code_executor = {
       cpu = 2048
       memory = 4096
     }
@@ -199,6 +210,12 @@ variable "workflows_enabled" {
   type        = bool
   default     = false
   description = "Whether to enable Workflows-specific containers, services, etc.. Defaults to false."
+}
+
+variable "code_executor_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether to enable code_executor service to support Python execution. Defaults to false."
 }
 
 variable "log_retention_in_days" {


### PR DESCRIPTION
Support code executor (and therefore python execution) in our ECS templates. Use `var. code_executor_enabled` to toggle the extra ECS service etc..