### PR TITLE
fix(aws_ecs): Vinculate missing Temporal BD Performance insights option

### DIFF
--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -523,6 +523,7 @@ module "temporal" {
   subnet_ids = var.private_subnet_ids
   private_dns_namespace_id = aws_service_discovery_private_dns_namespace.retoolsvc[0].id
   aws_cloudwatch_log_group_id = aws_cloudwatch_log_group.this.id
+  temporal_aurora_performance_insights_enabled = var.temporal_aurora_performance_insights_enabled
   aws_region = var.aws_region
   aws_ecs_cluster_id = aws_ecs_cluster.this.id
   launch_type = var.launch_type

--- a/modules/aws_ecs/temporal/main.tf
+++ b/modules/aws_ecs/temporal/main.tf
@@ -10,7 +10,8 @@ module "temporal_aurora_rds" {
 
   vpc_id               = var.vpc_id
 
-  monitoring_interval = 60
+  performance_insights_enabled = var.temporal_aurora_performance_insights_enabled
+  monitoring_interval          = 60
 
   # Create DB Subnet group using var.subnet_ids
   create_db_subnet_group = true


### PR DESCRIPTION
This pull request primarily focuses on enabling performance insights for the Temporal Aurora RDS in the `aws_ecs` module. The most significant changes include adding the `temporal_aurora_performance_insights_enabled` variable to the `temporal` and `temporal_aurora_rds` modules.

Here are the key changes:

* [`modules/aws_ecs/main.tf`](diffhunk://#diff-cf640c857cd351e91e95fe342432a78703dd9c5e44f850c3047c596cd2e2cd51R526): Added `temporal_aurora_performance_insights_enabled` variable to the `temporal` module. This will enable the performance insights for Temporal Aurora.
* [`modules/aws_ecs/temporal/main.tf`](diffhunk://#diff-f46d7df73d1b63c28332e918d82c798468e871dfc8e02c239c8ed96a0931b83fR13): Added `performance_insights_enabled` variable to the `temporal_aurora_rds` module. This variable is set using `temporal_aurora_performance_insights_enabled`, allowing for the enabling of performance insights in the Temporal Aurora RDS.