### PR TITLE
Add configuration variables for Retool & Temporal RDS clusters/instances

### DIFF
--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -37,6 +37,7 @@ resource "aws_db_instance" "this" {
   vpc_security_group_ids       = [aws_security_group.rds.id]
   db_subnet_group_name         = aws_db_subnet_group.this.id
   performance_insights_enabled = var.rds_performance_insights_enabled
+  storage_encrypted            = var.rds_instance_storage_encrypted
 
   skip_final_snapshot = true
   apply_immediately   = true
@@ -532,6 +533,10 @@ module "temporal" {
   private_dns_namespace_id                     = aws_service_discovery_private_dns_namespace.retoolsvc[0].id
   aws_cloudwatch_log_group_id                  = aws_cloudwatch_log_group.this.id
   temporal_aurora_performance_insights_enabled = var.temporal_aurora_performance_insights_enabled
+  temporal_aurora_engine_version               = var.temporal_aurora_engine_version
+  temporal_aurora_serverless_min_capacity      = var.temporal_aurora_serverless_min_capacity
+  temporal_aurora_serverless_max_capacity      = var.temporal_aurora_serverless_max_capacity
+  temporal_aurora_instances                    = var.temporal_aurora_instances
   aws_region                                   = var.aws_region
   aws_ecs_cluster_id                           = aws_ecs_cluster.this.id
   launch_type                                  = var.launch_type

--- a/modules/aws_ecs/temporal/main.tf
+++ b/modules/aws_ecs/temporal/main.tf
@@ -5,7 +5,7 @@ module "temporal_aurora_rds" {
   name="${var.deployment_name}-temporal-rds-instance"
   engine            = "aurora-postgresql"
   engine_mode       = "provisioned"
-  engine_version    = "14.5"
+  engine_version    = var.temporal_aurora_engine_version
   storage_encrypted = true
 
   vpc_id               = var.vpc_id
@@ -25,8 +25,8 @@ module "temporal_aurora_rds" {
   skip_final_snapshot = true
 
   serverlessv2_scaling_configuration = {
-    min_capacity = 0.5
-    max_capacity = 10
+    min_capacity = var.temporal_aurora_serverless_min_capacity
+    max_capacity = var.temporal_aurora_serverless_max_capacity
   }
 
   security_group_rules = {
@@ -36,9 +36,7 @@ module "temporal_aurora_rds" {
   }
 
   instance_class = "db.serverless"
-  instances = {
-    one = {}
-  }
+  instances      = var.temporal_aurora_instances
 }
 
 resource "aws_service_discovery_service" "temporal_frontend_service" { 

--- a/modules/aws_ecs/temporal/variables.tf
+++ b/modules/aws_ecs/temporal/variables.tf
@@ -98,6 +98,31 @@ variable "temporal_aurora_performance_insights_retention_period" {
   description = "The time in days to retain Performance Insights for Temporal Aurora. Defaults to 14."
 }
 
+variable "temporal_aurora_engine_version" {
+  type        = string
+  default     = "14.5"
+  description = "Engine version for Temporal Aurora. Defaults to 14.5."
+}
+
+variable "temporal_aurora_serverless_min_capacity" {
+  type        = number
+  default     = 0.5
+  description = "Minimum capacity for Temporal Aurora Serverless. Defaults to 0.5."
+}
+
+variable "temporal_aurora_serverless_max_capacity" {
+  type        = number
+  default     = 10
+  description = "Maximum capacity for Temporal Aurora Serverless. Defaults to 10."
+}
+
+variable "temporal_aurora_instances" {
+  type = any
+  default = {
+    one = {}
+  }
+}
+
 variable "additional_temporal_env_vars" {
   type        = list(map(string))
   default     = []

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -170,6 +170,12 @@ variable "rds_ca_cert_identifier" {
   description = "The identifier of the CA certificate for the DB instance"
 }
 
+variable "rds_instance_storage_encrypted" {
+  type        = bool
+  default     = false
+  description = "Whether the RDS instance should have storage encrypted. Defaults to false."
+}
+
 variable "use_exising_temporal_cluster" {
   type        = bool
   default     = false
@@ -234,6 +240,31 @@ variable "temporal_aurora_performance_insights_retention_period" {
   type        = number
   default     = 14
   description = "The time in days to retain Performance Insights for Temporal Aurora. Defaults to 14."
+}
+
+variable "temporal_aurora_engine_version" {
+  type        = string
+  default     = "14.5"
+  description = "Engine version for Temporal Aurora. Defaults to 14.5."
+}
+
+variable "temporal_aurora_serverless_min_capacity" {
+  type        = number
+  default     = 0.5
+  description = "Minimum capacity for Temporal Aurora Serverless. Defaults to 0.5."
+}
+
+variable "temporal_aurora_serverless_max_capacity" {
+  type        = number
+  default     = 10
+  description = "Maximum capacity for Temporal Aurora Serverless. Defaults to 10."
+}
+
+variable "temporal_aurora_instances" {
+  type = any
+  default = {
+    one = {}
+  }
 }
 
 variable "workflows_enabled" {


### PR DESCRIPTION
This pull request primarily focuses on enhancing the configurability of the AWS ECS module for the Temporal Aurora and RDS instance. The changes introduce new variables to allow customization of engine version, serverless capacity, and instances for Temporal Aurora, as well as enabling storage encryption for the RDS instance.

Key changes include:

### New Variables Introduced:

* `modules/aws_ecs/temporal/variables.tf` and `modules/aws_ecs/variables.tf`: Introduced new variables `temporal_aurora_engine_version`, `temporal_aurora_serverless_min_capacity`, `temporal_aurora_serverless_max_capacity`, `temporal_aurora_instances`, and `rds_instance_storage_encrypted` to allow customization of Temporal Aurora and RDS instance settings. [[1]](diffhunk://#diff-ad6c9ff493e73304187938f946e94aa9e750622afbf2569c409903dc46e68c7eR101-R125) [[2]](diffhunk://#diff-88a9d833d7d9549c4196df2a6b31a55fc9a6489dcdfa4c4290348e1854cebbbaR173-R178) [[3]](diffhunk://#diff-88a9d833d7d9549c4196df2a6b31a55fc9a6489dcdfa4c4290348e1854cebbbaR245-R269)

### Use of New Variables:

* [`modules/aws_ecs/main.tf`](diffhunk://#diff-cf640c857cd351e91e95fe342432a78703dd9c5e44f850c3047c596cd2e2cd51R40): The new variables `rds_instance_storage_encrypted` and `temporal_aurora_engine_version`, `temporal_aurora_serverless_min_capacity`, `temporal_aurora_serverless_max_capacity`, `temporal_aurora_instances` are now used in the "aws_db_instance" and "temporal" modules respectively. [[1]](diffhunk://#diff-cf640c857cd351e91e95fe342432a78703dd9c5e44f850c3047c596cd2e2cd51R40) [[2]](diffhunk://#diff-cf640c857cd351e91e95fe342432a78703dd9c5e44f850c3047c596cd2e2cd51R536-R539)

* [`modules/aws_ecs/temporal/main.tf`](diffhunk://#diff-f46d7df73d1b63c28332e918d82c798468e871dfc8e02c239c8ed96a0931b83fL8-R8): The new variables `temporal_aurora_engine_version`, `temporal_aurora_serverless_min_capacity`, `temporal_aurora_serverless_max_capacity`, and `temporal_aurora_instances` are now used in the "temporal_aurora_rds" module. [[1]](diffhunk://#diff-f46d7df73d1b63c28332e918d82c798468e871dfc8e02c239c8ed96a0931b83fL8-R8) [[2]](diffhunk://#diff-f46d7df73d1b63c28332e918d82c798468e871dfc8e02c239c8ed96a0931b83fL28-R29) [[3]](diffhunk://#diff-f46d7df73d1b63c28332e918d82c798468e871dfc8e02c239c8ed96a0931b83fL39-R39)

All the new configuration variables have been given their previous non-configurable values to keep full backwards compatibility.
The `rds_instance_storage_encrypted` variable was defaulted to `false` because [that's the inherited value from the AWS Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#storage_encrypted).