### PR TITLE
feat: Add temporal_ecs_task_resource_map variable

### DIFF
--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -532,6 +532,32 @@ module "temporal" {
   subnet_ids                                   = var.private_subnet_ids
   private_dns_namespace_id                     = aws_service_discovery_private_dns_namespace.retoolsvc[0].id
   aws_cloudwatch_log_group_id                  = aws_cloudwatch_log_group.this.id
+  temporal_services_config = {
+    frontend = {
+      request_port    = 7233,
+      membership_port = 6933
+      cpu             = var.temporal_ecs_task_resource_map["frontend"]["cpu"]
+      memory          = var.temporal_ecs_task_resource_map["frontend"]["memory"]
+    },
+    history = {
+      request_port    = 7234,
+      membership_port = 6934
+      cpu             = var.temporal_ecs_task_resource_map["history"]["cpu"]
+      memory          = var.temporal_ecs_task_resource_map["history"]["memory"]
+    },
+    matching = {
+      request_port    = 7235,
+      membership_port = 6935
+      cpu             = var.temporal_ecs_task_resource_map["matching"]["cpu"]
+      memory          = var.temporal_ecs_task_resource_map["matching"]["memory"]
+    },
+    worker = {
+      request_port    = 7239,
+      membership_port = 6939
+      cpu             = var.temporal_ecs_task_resource_map["worker"]["cpu"]
+      memory          = var.temporal_ecs_task_resource_map["worker"]["memory"]
+    }
+  }
   temporal_aurora_performance_insights_enabled = var.temporal_aurora_performance_insights_enabled
   temporal_aurora_engine_version               = var.temporal_aurora_engine_version
   temporal_aurora_serverless_min_capacity      = var.temporal_aurora_serverless_min_capacity

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -110,6 +110,32 @@ variable "ecs_task_resource_map" {
   description = "Amount of CPU and Memory provisioned for each task."
 }
 
+variable "temporal_ecs_task_resource_map" {
+  type = map(object({
+      cpu    = number
+      memory = number
+  }))
+  default = {
+    frontend = {
+      cpu    = 512
+      memory = 1024
+    },
+    history = {
+      cpu    = 512
+      memory = 2048
+    },
+    matching = {
+      cpu    = 512
+      memory = 1024
+    },
+    worker = {
+      cpu    = 512
+      memory = 1024
+    }
+  }
+  description = "Amount of CPU and Memory provisioned for each Temporal task."
+}
+
 variable "force_deployment" {
   type        = string
   default     = false


### PR DESCRIPTION
This pull request includes changes to the Terraform configuration files `modules/aws_ecs/main.tf` and `modules/aws_ecs/variables.tf`. The changes introduce a new variable `temporal_ecs_task_resource_map` and use it to configure the resources for Temporal services in the ECS module. The most important changes are:

* [`modules/aws_ecs/variables.tf`](diffhunk://#diff-88a9d833d7d9549c4196df2a6b31a55fc9a6489dcdfa4c4290348e1854cebbbaR113-R138): Introduced a new variable `temporal_ecs_task_resource_map` of type `map` that specifies the amount of CPU and memory provisioned for each Temporal task. The map keys include `frontend`, `history`, `matching`, and `worker`, each associated with an object specifying `cpu` and `memory` values.
* [`modules/aws_ecs/main.tf`](diffhunk://#diff-cf640c857cd351e91e95fe342432a78703dd9c5e44f850c3047c596cd2e2cd51R535-R560): Added a new `temporal_services_config` block in the `module "temporal"` block. This new block uses the `temporal_ecs_task_resource_map` variable to set the CPU and memory for each Temporal service. Each service also has its own `request_port` and `membership_port` specified.