### PR TITLE
Enable deletion of workflows services if workflows_enabled is set to false after creation

### DIFF
--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -478,7 +478,7 @@ resource "aws_ecs_task_definition" "retool_code_executor" {
 }
 
 resource "aws_service_discovery_private_dns_namespace" "retoolsvc" {
-  count       = var.workflows_enabled ? 1 : 0
+  count       = var.workflows_enabled || var.code_executor_enabled ? 1 : 0
   name        = "retoolsvc"
   description = "Service Discovery namespace for Retool deployment"
   vpc         = var.vpc_id


### PR DESCRIPTION
## Issue related:
https://github.com/tryretool/terraform-retool-modules/issues/58

- I had the issue because we are depending on the `workflows_enabled` variable only even if `code_executor_enabled` is true.

## Update:
Depend on the namespace creation for both.