### PR TITLE
Add more variables to configure RDS

### DIFF
--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -39,6 +39,7 @@ resource "aws_db_instance" "this" {
   performance_insights_enabled = var.rds_performance_insights_enabled
   storage_encrypted            = var.rds_instance_storage_encrypted
   storage_type                 = var.rds_storage_type
+  storage_throughput           = rds_storage_throughput
 
   skip_final_snapshot = true
   apply_immediately   = true

--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -39,7 +39,7 @@ resource "aws_db_instance" "this" {
   performance_insights_enabled = var.rds_performance_insights_enabled
   storage_encrypted            = var.rds_instance_storage_encrypted
   storage_type                 = var.rds_storage_type
-  storage_throughput           = rds_storage_throughput
+  storage_throughput           = var.rds_storage_throughput
 
   skip_final_snapshot = true
   apply_immediately   = true

--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -23,7 +23,7 @@ resource "aws_db_subnet_group" "this" {
 
 resource "aws_db_instance" "this" {
   identifier                   = "${var.deployment_name}-rds-instance"
-  allocated_storage            = 80
+  allocated_storage            = var.rds_allocated_storage
   instance_class               = var.rds_instance_class
   ca_cert_identifier           = var.rds_ca_cert_identifier
   engine                       = "postgres"

--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -38,6 +38,7 @@ resource "aws_db_instance" "this" {
   db_subnet_group_name         = aws_db_subnet_group.this.id
   performance_insights_enabled = var.rds_performance_insights_enabled
   storage_encrypted            = var.rds_instance_storage_encrypted
+  storage_type                 = var.rds_storage_type
 
   skip_final_snapshot = true
   apply_immediately   = true

--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -40,6 +40,7 @@ resource "aws_db_instance" "this" {
   storage_encrypted            = var.rds_instance_storage_encrypted
   storage_type                 = var.rds_storage_type
   storage_throughput           = var.rds_storage_throughput
+  iops                         = var.rds_iops
 
   skip_final_snapshot = true
   apply_immediately   = true

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -216,11 +216,14 @@ variable "rds_storage_type" {
 
 variable "rds_storage_throughput" {
   type        = number
+  default     = null
   description = "The storage throughput (only valid when using rds_storage_type = gp3)"
+
 }
 
 variable "rds_iops" {
   type        = number
+  default     = null
   description = "The storage provisioned IOPS  (only valid when using rds_storage_type = io1, io2, or gp3)"
 }
 

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -208,6 +208,12 @@ variable "rds_allocated_storage" {
   description = "The allocated storage in gibibytes. Defaults to 80"
 }
 
+variable "rds_storage_type" {
+  type        = string
+  default     = "gp2"
+  description = "The storage volume type (standard, gp2, gp3, io1, or io2). Defaults to gp2"
+}
+
 variable "use_existing_temporal_cluster" {
   type        = bool
   default     = false

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -214,6 +214,11 @@ variable "rds_storage_type" {
   description = "The storage volume type (standard, gp2, gp3, io1, or io2). Defaults to gp2"
 }
 
+variable "rds_storage_throughput" {
+  type        = number
+  description = "The storage throughput, in OPS, when using rds_storage_type = gp3"
+}
+
 variable "use_existing_temporal_cluster" {
   type        = bool
   default     = false

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -216,7 +216,12 @@ variable "rds_storage_type" {
 
 variable "rds_storage_throughput" {
   type        = number
-  description = "The storage throughput, in OPS, when using rds_storage_type = gp3"
+  description = "The storage throughput (only valid when using rds_storage_type = gp3)"
+}
+
+variable "rds_iops" {
+  type        = number
+  description = "The storage provisioned IOPS  (only valid when using rds_storage_type = io1, io2, or gp3)"
 }
 
 variable "use_existing_temporal_cluster" {

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -202,6 +202,12 @@ variable "rds_instance_storage_encrypted" {
   description = "Whether the RDS instance should have storage encrypted. Defaults to false."
 }
 
+variable "rds_allocated_storage" {
+  type        = number
+  default     = 80
+  description = "The allocated storage in gibibytes. Defaults to 80"
+}
+
 variable "use_existing_temporal_cluster" {
   type        = bool
   default     = false


### PR DESCRIPTION
Adds more variables used to configure RDS, this was useful when I was trying to meet our org policies around RDS cost control.

Adds:

* `rds_allocated_storage`
* `rds_storage_type`
* `rds_storage_throughput`
* `rds_iops`