### PR TITLE
Add telemetry support for ECS

### DIFF
--- a/modules/aws_ecs/README.md
+++ b/modules/aws_ecs/README.md
@@ -101,6 +101,15 @@ container_egress_rules = [
 ]
 ```
 
+### Telemetry
+**Note: telemetry collection is currently supported only on Fargate clusters.**
+
+To enable telemetry collection, set the variable `telemetry_enabled` to `true` (see [variables.tf](variables.tf#L340)).
+You may also enable forwarding telemetry data to Retool by setting the variable `telemetry_send_to_retool` to `true`.
+
+Similar to Helm deployments, [custom configuration](https://docs.retool.com/self-hosted/guides/telemetry#send-telemetry-data-to-custom-destinations) may be passed into the Retool telemetry collector.
+To use custom configuration, set [`telemetry_use_custom_config`](variables.tf#L352) to `true`, and supply your custom config in the file named in [`telemetry_custom_config_path`](variables.tf#L358).
+
 ### Environment Variables
 
 To add additional [Retool environment variables](https://docs.retool.com/docs/environment-variables) to your deployment, populate the `additional_env_vars` input variable into the module.

--- a/modules/aws_ecs/fluentbit/Dockerfile
+++ b/modules/aws_ecs/fluentbit/Dockerfile
@@ -1,0 +1,8 @@
+# This file is provided as an example of custom configuration on top of the AWS
+# fluent-bit sidecar image. The default image referenced in locals.tf is built
+# and supplied by Retool.
+
+FROM amazon/aws-for-fluent-bit:2.32.3 AS retool-aws-for-fluent-bit
+
+ADD retool-entrypoint.sh /retool-entrypoint.sh
+CMD /retool-entrypoint.sh

--- a/modules/aws_ecs/fluentbit/retool-entrypoint.sh
+++ b/modules/aws_ecs/fluentbit/retool-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euf -o pipefail
+
+config=$(cat <<EOF
+[OUTPUT]
+    Name    forward
+    Match   retool-firelens*
+    Host    telemetry.${SERVICE_DISCOVERY_NAMESPACE}
+    Port    9000
+EOF
+)
+
+echo "$config" > /extra.conf
+exec /entrypoint.sh

--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -55,6 +55,7 @@ resource "aws_ecs_service" "retool" {
   deployment_minimum_healthy_percent = var.minimum_healthy_percent
   iam_role                           = var.launch_type == "EC2" ? aws_iam_role.service_role.arn : null
   propagate_tags                     = var.task_propagate_tags
+  enable_execute_command             = var.enable_execute_command
 
   load_balancer {
     target_group_arn = aws_lb_target_group.this.arn
@@ -72,7 +73,6 @@ resource "aws_ecs_service" "retool" {
   dynamic "network_configuration" {
     for_each = var.launch_type == "FARGATE" ? toset([1]) : toset([])
 
-
     content {
       subnets = var.private_subnet_ids
       security_groups = [
@@ -84,11 +84,12 @@ resource "aws_ecs_service" "retool" {
 }
 
 resource "aws_ecs_service" "jobs_runner" {
-  name            = "${var.deployment_name}-jobs-runner-service"
-  cluster         = aws_ecs_cluster.this.id
-  desired_count   = 1
-  task_definition = aws_ecs_task_definition.retool_jobs_runner.arn
-  propagate_tags  = var.task_propagate_tags
+  name                   = "${var.deployment_name}-jobs-runner-service"
+  cluster                = aws_ecs_cluster.this.id
+  desired_count          = 1
+  task_definition        = aws_ecs_task_definition.retool_jobs_runner.arn
+  propagate_tags         = var.task_propagate_tags
+  enable_execute_command = var.enable_execute_command
 
   # Need to explictly set this in aws_ecs_service to avoid destructive behavior: https://github.com/hashicorp/terraform-provider-aws/issues/22823
   capacity_provider_strategy {
@@ -98,7 +99,6 @@ resource "aws_ecs_service" "jobs_runner" {
   }
 
   dynamic "network_configuration" {
-
     for_each = var.launch_type == "FARGATE" ? toset([1]) : toset([])
 
     content {
@@ -112,12 +112,13 @@ resource "aws_ecs_service" "jobs_runner" {
 }
 
 resource "aws_ecs_service" "workflows_backend" {
-  count           = var.workflows_enabled ? 1 : 0
-  name            = "${var.deployment_name}-workflows-backend-service"
-  cluster         = aws_ecs_cluster.this.id
-  desired_count   = 1
-  task_definition = aws_ecs_task_definition.retool_workflows_backend[0].arn
-  propagate_tags  = var.task_propagate_tags
+  count                  = var.workflows_enabled ? 1 : 0
+  name                   = "${var.deployment_name}-workflows-backend-service"
+  cluster                = aws_ecs_cluster.this.id
+  desired_count          = 1
+  task_definition        = aws_ecs_task_definition.retool_workflows_backend[0].arn
+  propagate_tags         = var.task_propagate_tags
+  enable_execute_command = var.enable_execute_command
 
   # Need to explictly set this in aws_ecs_service to avoid destructive behavior: https://github.com/hashicorp/terraform-provider-aws/issues/22823
   capacity_provider_strategy {
@@ -129,8 +130,8 @@ resource "aws_ecs_service" "workflows_backend" {
   service_registries {
     registry_arn = aws_service_discovery_service.retool_workflow_backend_service[0].arn
   }
-  dynamic "network_configuration" {
 
+  dynamic "network_configuration" {
     for_each = var.launch_type == "FARGATE" ? toset([1]) : toset([])
 
     content {
@@ -144,12 +145,13 @@ resource "aws_ecs_service" "workflows_backend" {
 }
 
 resource "aws_ecs_service" "workflows_worker" {
-  count           = var.workflows_enabled ? 1 : 0
-  name            = "${var.deployment_name}-workflows-worker-service"
-  cluster         = aws_ecs_cluster.this.id
-  desired_count   = 1
-  task_definition = aws_ecs_task_definition.retool_workflows_worker[0].arn
-  propagate_tags  = var.task_propagate_tags
+  count                  = var.workflows_enabled ? 1 : 0
+  name                   = "${var.deployment_name}-workflows-worker-service"
+  cluster                = aws_ecs_cluster.this.id
+  desired_count          = 1
+  task_definition        = aws_ecs_task_definition.retool_workflows_worker[0].arn
+  propagate_tags         = var.task_propagate_tags
+  enable_execute_command = var.enable_execute_command
 
   # Need to explictly set this in aws_ecs_service to avoid destructive behavior: https://github.com/hashicorp/terraform-provider-aws/issues/22823
   capacity_provider_strategy {
@@ -157,8 +159,8 @@ resource "aws_ecs_service" "workflows_worker" {
     weight            = 100
     capacity_provider = var.launch_type == "FARGATE" ? "FARGATE" : aws_ecs_capacity_provider.this[0].name
   }
-  dynamic "network_configuration" {
 
+  dynamic "network_configuration" {
     for_each = var.launch_type == "FARGATE" ? toset([1]) : toset([])
 
     content {
@@ -172,11 +174,12 @@ resource "aws_ecs_service" "workflows_worker" {
 }
 
 resource "aws_ecs_service" "code_executor" {
-  count           = var.code_executor_enabled ? 1 : 0
-  name            = "${var.deployment_name}-code-executor-service"
-  cluster         = aws_ecs_cluster.this.id
-  desired_count   = 1
-  task_definition = aws_ecs_task_definition.retool_code_executor[0].arn
+  count                  = var.code_executor_enabled ? 1 : 0
+  name                   = "${var.deployment_name}-code-executor-service"
+  cluster                = aws_ecs_cluster.this.id
+  desired_count          = 1
+  task_definition        = aws_ecs_task_definition.retool_code_executor[0].arn
+  enable_execute_command = var.enable_execute_command
 
   # Need to explictly set this in aws_ecs_service to avoid destructive behavior: https://github.com/hashicorp/terraform-provider-aws/issues/22823
   capacity_provider_strategy {
@@ -188,8 +191,41 @@ resource "aws_ecs_service" "code_executor" {
   service_registries {
     registry_arn = aws_service_discovery_service.retool_code_executor_service[0].arn
   }
-  dynamic "network_configuration" {
 
+  dynamic "network_configuration" {
+    for_each = var.launch_type == "FARGATE" ? toset([1]) : toset([])
+
+    content {
+      subnets = var.private_subnet_ids
+      security_groups = [
+        aws_security_group.containers.id
+      ]
+      assign_public_ip = true
+    }
+  }
+}
+
+resource "aws_ecs_service" "telemetry" {
+  count                  = var.telemetry_enabled ? 1 : 0
+  name                   = "${var.deployment_name}-telemetry-service"
+  cluster                = aws_ecs_cluster.this.id
+  desired_count          = 1
+  task_definition        = aws_ecs_task_definition.retool_telemetry[0].arn
+  propagate_tags         = var.task_propagate_tags
+  enable_execute_command = var.enable_execute_command
+
+  # Need to explictly set this in aws_ecs_service to avoid destructive behavior: https://github.com/hashicorp/terraform-provider-aws/issues/22823
+  capacity_provider_strategy {
+    base              = 1
+    weight            = 100
+    capacity_provider = var.launch_type == "FARGATE" ? "FARGATE" : aws_ecs_capacity_provider.this[0].name
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.retool_telemetry_service[0].arn
+  }
+
+  dynamic "network_configuration" {
     for_each = var.launch_type == "FARGATE" ? toset([1]) : toset([])
 
     content {
@@ -210,7 +246,8 @@ resource "aws_ecs_task_definition" "retool_jobs_runner" {
   network_mode             = var.launch_type == "FARGATE" ? "awsvpc" : "bridge"
   cpu                      = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["jobs_runner"]["cpu"] : null
   memory                   = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["jobs_runner"]["memory"] : null
-  container_definitions = jsonencode(
+  container_definitions = jsonencode(concat(
+    local.common_containers,
     [
       {
         name      = "retool-jobs-runner"
@@ -222,14 +259,7 @@ resource "aws_ecs_task_definition" "retool_jobs_runner" {
           "./docker_scripts/start_api.sh"
         ]
 
-        logConfiguration = {
-          logDriver = "awslogs"
-          options = {
-            awslogs-group         = aws_cloudwatch_log_group.this.id
-            awslogs-region        = var.aws_region
-            awslogs-stream-prefix = "SERVICE_RETOOL"
-          }
-        }
+        logConfiguration = local.task_log_configuration
 
         portMappings = [
           {
@@ -250,8 +280,9 @@ resource "aws_ecs_task_definition" "retool_jobs_runner" {
         )
       }
     ]
-  )
+  ))
 }
+
 resource "aws_ecs_task_definition" "retool" {
   family                   = "retool"
   task_role_arn            = aws_iam_role.task_role.arn
@@ -260,7 +291,9 @@ resource "aws_ecs_task_definition" "retool" {
   network_mode             = var.launch_type == "FARGATE" ? "awsvpc" : "bridge"
   cpu                      = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["main"]["cpu"] : null
   memory                   = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["main"]["memory"] : null
-  container_definitions = jsonencode(
+
+  container_definitions = jsonencode(concat(
+    local.common_containers,
     [
       {
         name      = "retool"
@@ -272,14 +305,7 @@ resource "aws_ecs_task_definition" "retool" {
           "./docker_scripts/start_api.sh"
         ]
 
-        logConfiguration = {
-          logDriver = "awslogs"
-          options = {
-            awslogs-group         = aws_cloudwatch_log_group.this.id
-            awslogs-region        = var.aws_region
-            awslogs-stream-prefix = "SERVICE_RETOOL"
-          }
-        }
+        logConfiguration = local.task_log_configuration
 
         portMappings = [
           {
@@ -304,7 +330,7 @@ resource "aws_ecs_task_definition" "retool" {
         )
       }
     ]
-  )
+  ))
 }
 
 resource "aws_ecs_task_definition" "retool_workflows_backend" {
@@ -316,7 +342,9 @@ resource "aws_ecs_task_definition" "retool_workflows_backend" {
   network_mode             = var.launch_type == "FARGATE" ? "awsvpc" : "bridge"
   cpu                      = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["workflows_backend"]["cpu"] : null
   memory                   = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["workflows_backend"]["memory"] : null
-  container_definitions = jsonencode(
+
+  container_definitions = jsonencode(concat(
+    local.common_containers,
     [
       {
         name      = "retool-workflows-backend"
@@ -328,14 +356,7 @@ resource "aws_ecs_task_definition" "retool_workflows_backend" {
           "./docker_scripts/start_api.sh"
         ]
 
-        logConfiguration = {
-          logDriver = "awslogs"
-          options = {
-            awslogs-group         = aws_cloudwatch_log_group.this.id
-            awslogs-region        = var.aws_region
-            awslogs-stream-prefix = "SERVICE_RETOOL"
-          }
-        }
+        logConfiguration = local.task_log_configuration
 
         portMappings = [
           {
@@ -360,8 +381,9 @@ resource "aws_ecs_task_definition" "retool_workflows_backend" {
         )
       }
     ]
-  )
+  ))
 }
+
 resource "aws_ecs_task_definition" "retool_workflows_worker" {
   count                    = var.workflows_enabled ? 1 : 0
   family                   = "retool-workflows-worker"
@@ -371,7 +393,9 @@ resource "aws_ecs_task_definition" "retool_workflows_worker" {
   network_mode             = var.launch_type == "FARGATE" ? "awsvpc" : "bridge"
   cpu                      = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["workflows_worker"]["cpu"] : null
   memory                   = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["workflows_worker"]["memory"] : null
-  container_definitions = jsonencode(
+
+  container_definitions = jsonencode(concat(
+    local.common_containers,
     [
       {
         name      = "retool-workflows-worker"
@@ -383,14 +407,7 @@ resource "aws_ecs_task_definition" "retool_workflows_worker" {
           "./docker_scripts/start_api.sh"
         ]
 
-        logConfiguration = {
-          logDriver = "awslogs"
-          options = {
-            awslogs-group         = aws_cloudwatch_log_group.this.id
-            awslogs-region        = var.aws_region
-            awslogs-stream-prefix = "SERVICE_RETOOL"
-          }
-        }
+        logConfiguration = local.task_log_configuration
 
         health_check = {
           command = ["CMD-SHELL", "curl http://localhost/api/checkHealth:3005 || exit 1"]
@@ -419,7 +436,7 @@ resource "aws_ecs_task_definition" "retool_workflows_worker" {
         )
       }
     ]
-  )
+  ))
 }
 
 resource "aws_ecs_task_definition" "retool_code_executor" {
@@ -431,7 +448,9 @@ resource "aws_ecs_task_definition" "retool_code_executor" {
   network_mode             = var.launch_type == "FARGATE" ? "awsvpc" : "bridge"
   cpu                      = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["code_executor"]["cpu"] : null
   memory                   = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["code_executor"]["memory"] : null
-  container_definitions = jsonencode(
+
+  container_definitions = jsonencode(concat(
+    local.common_containers,
     [
       {
         name      = "retool-code-executor"
@@ -444,14 +463,7 @@ resource "aws_ecs_task_definition" "retool_code_executor" {
           "./start.sh"
         ]
 
-        logConfiguration = {
-          logDriver = "awslogs"
-          options = {
-            awslogs-group         = aws_cloudwatch_log_group.this.id
-            awslogs-region        = var.aws_region
-            awslogs-stream-prefix = "SERVICE_RETOOL"
-          }
-        }
+        logConfiguration = local.task_log_configuration
 
         health_check = {
           command = ["CMD-SHELL", "curl http://localhost/api/checkHealth:3004 || exit 1"]
@@ -477,11 +489,94 @@ resource "aws_ecs_task_definition" "retool_code_executor" {
         )
       }
     ]
+  ))
+}
+
+resource "aws_ecs_task_definition" "retool_telemetry" {
+  count                    = var.telemetry_enabled ? 1 : 0
+  family                   = "retool-telemetry"
+  task_role_arn            = aws_iam_role.task_role.arn
+  execution_role_arn       = var.launch_type == "FARGATE" ? aws_iam_role.execution_role[0].arn : null
+  requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : null
+  network_mode             = var.launch_type == "FARGATE" ? "awsvpc" : "bridge"
+  cpu                      = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["telemetry"]["cpu"] : null
+  memory                   = var.launch_type == "FARGATE" ? var.ecs_task_resource_map["telemetry"]["memory"] : null
+
+  container_definitions = jsonencode(
+    [
+      {
+        name      = "retool-telemetry"
+        essential = true
+        image     = local.ecs_telemetry_image
+        cpu       = var.launch_type == "EC2" ? var.ecs_task_resource_map["telemetry"]["cpu"] : null
+        memory    = var.launch_type == "EC2" ? var.ecs_task_resource_map["telemetry"]["memory"] : null
+        command = [
+          "retool-telemetry"
+        ]
+
+        logConfiguration = {
+          logDriver = "awslogs"
+          options = {
+            awslogs-group         = aws_cloudwatch_log_group.this.id
+            awslogs-region        = var.aws_region
+            awslogs-stream-prefix = "SERVICE_RETOOL"
+          }
+        }
+
+        portMappings = [
+          {
+            containerPort = 4317
+            hostPort      = 4317
+            protocol      = "tcp"
+          },
+          {
+            containerPort = 9000
+            hostPort      = 9000
+            protocol      = "tcp"
+          },
+          {
+            containerPort = 9090
+            hostPort      = 9090
+            protocol      = "tcp"
+          },
+          {
+            containerPort = 9125
+            hostPort      = 9125
+            protocol      = "udp"
+          },
+          {
+            containerPort = 9126
+            hostPort      = 9126
+            protocol      = "udp"
+          }
+        ]
+
+        environment = concat(
+          local.environment_variables,
+          [
+            {
+              name  = "RTEL_DEPLOYMENT_MODE"
+              value = "aws-ecs"
+            },
+            {
+              name  = "RTEL_SEND_TO_RETOOL"
+              value = tostring(var.telemetry_send_to_retool)
+            }
+          ],
+          var.telemetry_use_custom_config ? [
+            {
+              name  = "VECTOR_CUSTOM_CONFIG_ECS"
+              value = base64encode(file(var.telemetry_custom_config_path))
+            }
+          ] : []
+        )
+      }
+    ]
   )
 }
 
 resource "aws_service_discovery_private_dns_namespace" "retool_namespace" {
-  count       = (var.code_executor_enabled || var.workflows_enabled) ? 1 : 0
+  count       = (var.code_executor_enabled || var.telemetry_enabled || var.workflows_enabled) ? 1 : 0
   name        = local.service_discovery_namespace
   description = "Service Discovery namespace for Retool deployment"
   vpc         = var.vpc_id
@@ -510,6 +605,26 @@ resource "aws_service_discovery_service" "retool_workflow_backend_service" {
 resource "aws_service_discovery_service" "retool_code_executor_service" {
   count = var.code_executor_enabled ? 1 : 0
   name  = "code-executor"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.retool_namespace[0].id
+
+    dns_records {
+      ttl  = 60
+      type = "A"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}
+
+resource "aws_service_discovery_service" "retool_telemetry_service" {
+  count = var.telemetry_enabled ? 1 : 0
+  name = "telemetry"
 
   dns_config {
     namespace_id = aws_service_discovery_private_dns_namespace.retool_namespace[0].id

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -73,16 +73,29 @@ variable "retool_license_key" {
   default     = "EXPIRED-LICENSE-KEY-TRIAL"
 }
 
+# TODO(v): update when published
 variable "ecs_retool_image" {
   type        = string
-  description = "Container image for desired Retool version. Defaults to `3.28.7`"
-  default     = "tryretool/backend:3.28.7"
+  description = "Container image for desired Retool version. Defaults to `3.75.7-stable`"
+  default     = "tryretool/backend:3.75.7-stable"
 }
 
 variable "ecs_code_executor_image" {
   type        = string
-  description = "Container image for desired code_executor version. Defaults to `3.28.7`"
-  default     = "tryretool/code-executor-service:3.28.7"
+  description = "Container image for desired code_executor version. Defaults to `3.75.7-stable`"
+  default     = "tryretool/code-executor-service:3.75.7-stable"
+}
+
+variable "ecs_telemetry_image" {
+  type        = string
+  description = "Container image for desired telemetry sidecar version. Defaults to same version as ecs_retool_image (see locals.tf)."
+  default     = ""
+}
+
+variable "ecs_telemetry_fluentbit_image" {
+  type        = string
+  description = "Container image for desired fluent-bit sidecar version. Defaults to same version as ecs_retool_image (see locals.tf)."
+  default     = ""
 }
 
 variable "ecs_task_resource_map" {
@@ -107,10 +120,17 @@ variable "ecs_task_resource_map" {
       cpu    = 2048
       memory = 4096
     }
-
     code_executor = {
       cpu    = 2048
       memory = 4096
+    }
+    telemetry = {
+      cpu    = 1024
+      memory = 2048
+    }
+    fluentbit = {
+      cpu    = 512
+      memory = 1024
     }
   }
   description = "Amount of CPU and Memory provisioned for each task."
@@ -168,8 +188,8 @@ variable "rds_instance_class" {
 
 variable "rds_instance_engine_version" {
   type        = string
-  default     = "13.7"
-  description = "Version of the Postgres RDS instance. Defaults to 13.7"
+  default     = "13.15"
+  description = "Version of the Postgres RDS instance. Defaults to 13.15"
 }
 
 variable "rds_instance_auto_minor_version_upgrade" {
@@ -346,6 +366,36 @@ variable "code_executor_enabled" {
   type        = bool
   default     = false
   description = "Whether to enable code_executor service to support Python execution. Defaults to false."
+}
+
+variable "telemetry_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether to enable on-prem telemetry. Defaults to false."
+}
+
+variable "telemetry_send_to_retool" {
+  type        = bool
+  default     = false
+  description = "Whether to send telemetry data to Retool. Defaults to false."
+}
+
+variable "telemetry_use_custom_config" {
+  type        = bool
+  default     = false
+  description = "Whether to use custom Vector configuration. Defaults to false."
+}
+
+variable "telemetry_custom_config_path" {
+  type        = string
+  default     = "vector-custom.yaml"
+  description = "Path to custom Vector configuration file for Retool telemetry. Defaults to vector-custom.yaml."
+}
+
+variable "enable_execute_command" {
+  type        = bool
+  default     = false
+  description = "Whether to enable command execution on containers (for debugging). Defaults to false."
 }
 
 variable "log_retention_in_days" {


### PR DESCRIPTION
Adds support for telemetry data collection in ECS deployments.

This adds a new ECS service that collects telemetry data and optionally forwards it to Retool. Custom Vector configuration is supported by passing it into the telemetry container through an environment variable.