### PR TITLE
Add an variable to configure Multi-AZ for RDS

### DIFF
--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -41,6 +41,7 @@ resource "aws_db_instance" "this" {
   storage_type                 = var.rds_storage_type
   storage_throughput           = var.rds_storage_throughput
   iops                         = var.rds_iops
+  multi_az                     = var.rds_multi_az
 
   skip_final_snapshot = true
   apply_immediately   = true

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -233,6 +233,12 @@ variable "rds_iops" {
   description = "The storage provisioned IOPS  (only valid when using rds_storage_type = io1, io2, or gp3)"
 }
 
+variable "rds_multi_az" {
+  type        = bool
+  default     = false
+  description = "Whether the RDS instance should have Multi-AZ enabled. Defaults to false."
+}
+
 variable "use_existing_temporal_cluster" {
   type        = bool
   default     = false

--- a/modules/aws_ecs_ec2/main.tf
+++ b/modules/aws_ecs_ec2/main.tf
@@ -156,6 +156,7 @@ resource "aws_db_instance" "this" {
   publicly_accessible          = var.rds_publicly_accessible
   vpc_security_group_ids       = [aws_security_group.rds.id]
   performance_insights_enabled = var.rds_performance_insights_enabled
+  multi_az                     = var.rds_multi_az
   
   skip_final_snapshot          = true
   apply_immediately           = true

--- a/modules/aws_ecs_ec2/variables.tf
+++ b/modules/aws_ecs_ec2/variables.tf
@@ -115,6 +115,12 @@ variable "rds_performance_insights_retention_period" {
   description = "The time in days to retain Performance Insights for RDS. Defaults to 14."
 }
 
+variable "rds_multi_az" {
+  type        = bool
+  default     = false
+  description = "Whether the RDS instance should have Multi-AZ enabled. Defaults to false."
+}
+
 variable "log_retention_in_days" {
   type        = number
   default     = 14


### PR DESCRIPTION
This pull request introduces support for enabling Multi-AZ deployments for this module. The changes include updates to both the `main.tf` and `variables.tf` files in the `modules/aws_ecs` and `modules/aws_ecs_ec2` directories.

Key changes include:

* [`modules/aws_ecs/main.tf`](diffhunk://#diff-cf640c857cd351e91e95fe342432a78703dd9c5e44f850c3047c596cd2e2cd51R44): Added the `multi_az` parameter to the `aws_db_instance` resource.
* [`modules/aws_ecs/variables.tf`](diffhunk://#diff-88a9d833d7d9549c4196df2a6b31a55fc9a6489dcdfa4c4290348e1854cebbbaR236-R241): Introduced a new variable `rds_multi_az` to control the Multi-AZ setting for RDS instances.
* [`modules/aws_ecs_ec2/main.tf`](diffhunk://#diff-fcce4ab129fafb0d565e6215d03208850004964c2ccec7bd03deadc8410aa749R159): Added the `multi_az` parameter to the `aws_db_instance` resource.
* [`modules/aws_ecs_ec2/variables.tf`](diffhunk://#diff-370d023b9c9657edd45a5274f473c9fef4e529290a27d71a5d0627046100e44dR118-R123): Introduced a new variable `rds_multi_az` to control the Multi-AZ setting for RDS instances.