### PR TITLE
bump instance size to 16gb memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Disclaimer: Please use these modules only if you're comfortable configuring Terr
 
 # Prerequisites
 
-- All modules have been test on **Hashicorp Terraform v1.3.7**
+- All modules have been tested on **Hashicorp Terraform v1.3.7**
 - The AWS Provider version is set to **v5.0**
 
 # Usage

--- a/modules/aws_ec2_standalone/variables.tf
+++ b/modules/aws_ec2_standalone/variables.tf
@@ -6,8 +6,8 @@ variable "aws_region" {
 
 variable "instance_type" {
   type        = string
-  default     = "t3.large"
-  description = "EC2 instance type. Defaults to `t3.large`."
+  default     = "t3.xlarge"
+  description = "EC2 instance type. Defaults to `t3.xlarge`."
 }
 
 variable "instance_name" {

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -33,8 +33,8 @@ variable "ssh_key_name" {
 
 variable "instance_type" {
   type        = string
-  description = "ECS cluster instance type. Defaults to `t2.large`"
-  default     = "t2.large"
+  description = "ECS cluster instance type. Defaults to `t3.xlarge`"
+  default     = "t3.xlarge"
 }
 
 variable "max_instance_count" {

--- a/modules/aws_ecs_ec2/variables.tf
+++ b/modules/aws_ecs_ec2/variables.tf
@@ -27,8 +27,8 @@ variable "ssh_key_name" {
 
 variable "instance_type" {
   type        = string
-  description = "ECS cluster instance type. Defaults to `t2.large`"
-  default     = "t2.large"
+  description = "ECS cluster instance type. Defaults to `t3.xlarge`"
+  default     = "t3.xlarge"
 }
 
 variable "max_instance_count" {


### PR DESCRIPTION
The instance sizes in these configurations were quite outdated. Bumping them up to be on par with the rest of our suggested configurations