### PR TITLE
Add security group to outputs

### DIFF
--- a/modules/aws_ec2_standalone/outputs.tf
+++ b/modules/aws_ec2_standalone/outputs.tf
@@ -17,3 +17,13 @@ output "ec2_public_ip" {
   value       = aws_instance.this.public_ip
   description = "Public IP of EC2 Instance"
 }
+
+output "ec2_security_group_arn" {
+  value       = aws_security_group.this.arn
+  description = "Security Group arn for EC2 instance"
+}
+
+output "ec2_security_group_id" {
+  value       = aws_security_group.this.id
+  description = "Security Group ID for EC2 instance"
+}

--- a/modules/aws_ecs/outputs.tf
+++ b/modules/aws_ecs/outputs.tf
@@ -8,6 +8,16 @@ output "ecs_alb_arn" {
   description = "Retool ALB arn"
 }
 
+output "ecs_alb_security_group_arn" {
+  value       = aws_security_group.alb.arn
+  description = "Security Group arn for Retool ALB"
+}
+
+output "ecs_alb_security_group_id" {
+  value       = aws_security_group.alb.id
+  description = "Security Group ID for Retool ALB"
+}
+
 output "ecs_cluster_name" {
   value       = aws_ecs_cluster.this.name
   description = "Name of AWS ECS Cluster"
@@ -21,6 +31,16 @@ output "ecs_cluster_arn" {
 output "ecs_cluster_id" {
   value       = aws_ecs_cluster.this.id
   description = "ID of AWS ECS Cluster"
+}
+
+output "ecs_containers_security_group_arn" {
+  value       = aws_security_group.containers.arn
+  description = "Security Group arn for Retool containers"
+}
+
+output "ecs_containers_security_group_id" {
+  value       = aws_security_group.containers.id
+  description = "Security Group ID for Retool containers"
 }
 
 output "rds_instance_id" {
@@ -41,6 +61,16 @@ output "rds_instance_arn" {
 output "rds_instance_name" {
   value       = aws_db_instance.this.db_name
   description = "Name of RDS instance"
+}
+
+output "rds_security_group_arn" {
+  value       = aws_security_group.rds.arn
+  description = "Security Group arn for RDS instance"
+}
+
+output "rds_security_group_id" {
+  value       = aws_security_group.rds.id
+  description = "Security Group ID for RDS instance"
 }
 
 output "target_group_arn" {

--- a/modules/aws_ecs_ec2/outputs.tf
+++ b/modules/aws_ecs_ec2/outputs.tf
@@ -8,6 +8,16 @@ output "ecs_alb_arn" {
   description = "Retool ALB arn"
 }
 
+output "ecs_alb_security_group_arn" {
+  value       = aws_security_group.alb.arn
+  description = "Security Group arn for Retool ALB"
+}
+
+output "ecs_alb_security_group_id" {
+  value       = aws_security_group.alb.id
+  description = "Security Group ID for Retool ALB"
+}
+
 output "ecs_cluster_name" {
   value       = aws_ecs_cluster.this.name
   description = "Name of AWS ECS Cluster"
@@ -21,6 +31,16 @@ output "ecs_cluster_arn" {
 output "ecs_cluster_id" {
   value       = aws_ecs_cluster.this.id
   description = "ID of AWS ECS Cluster"
+}
+
+output "ecs_ec2_security_group_arn" {
+  value       = aws_security_group.ec2.arn
+  description = "Security Group arn for Retool ec2"
+}
+
+output "ecs_ec2_security_group_id" {
+  value       = aws_security_group.ec2.id
+  description = "Security Group ID for Retool ec2"
 }
 
 output "rds_instance_id" {
@@ -41,4 +61,14 @@ output "rds_instance_arn" {
 output "rds_instance_name" {
   value       = aws_db_instance.this.db_name
   description = "Name of RDS instance"
+}
+
+output "rds_security_group_arn" {
+  value       = aws_security_group.rds.arn
+  description = "Security Group arn for RDS instance"
+}
+
+output "rds_security_group_id" {
+  value       = aws_security_group.rds.id
+  description = "Security Group ID for RDS instance"
 }


### PR DESCRIPTION
This pull request adds several new outputs to the Terraform modules for AWS EC2, ECS, and ECS EC2. These outputs provide the security group ARNs and IDs for various AWS resources, which can be useful for referencing these security groups in other parts of the infrastructure configuration.

New outputs added:

### AWS EC2 Module:
* Added `ec2_security_group_arn` and `ec2_security_group_id` outputs to provide the ARN and ID of the security group associated with the EC2 instance.

### AWS ECS Module:
* Added `ecs_alb_security_group_arn` and `ecs_alb_security_group_id` outputs to provide the ARN and ID of the security group associated with the Retool ALB.
* Added `ecs_containers_security_group_arn` and `ecs_containers_security_group_id` outputs to provide the ARN and ID of the security group associated with the Retool containers.
* Added `rds_security_group_arn` and `rds_security_group_id` outputs to provide the ARN and ID of the security group associated with the RDS instance.

### AWS ECS EC2 Module:
* Added `ecs_alb_security_group_arn` and `ecs_alb_security_group_id` outputs to provide the ARN and ID of the security group associated with the Retool ALB.
* Added `ecs_ec2_security_group_arn` and `ecs_ec2_security_group_id` outputs to provide the ARN and ID of the security group associated with the Retool EC2.
* Added `rds_security_group_arn` and `rds_security_group_id` outputs to provide the ARN and ID of the security group associated with the RDS instance.