### PR TITLE
Add AWS GovCloud Support

### DIFF
--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -701,4 +701,5 @@ module "temporal" {
   aws_ecs_capacity_provider_name               = var.launch_type == "EC2" ? aws_ecs_capacity_provider.this[0].name : null
   task_propagate_tags                          = var.task_propagate_tags
   service_discovery_namespace                  = local.service_discovery_namespace
+  iam_partition                                = var.iam_partition
 }

--- a/modules/aws_ecs/roles.tf
+++ b/modules/aws_ecs/roles.tf
@@ -90,7 +90,7 @@ resource "aws_iam_role" "execution_role" {
 resource "aws_iam_role_policy_attachment" "execution_role" {
   count      = var.launch_type == "FARGATE" ? 1 : 0
   role       = aws_iam_role.execution_role[0].name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+  policy_arn = "arn:${var.iam_partition}:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
 # IAM Role for EC2 instances

--- a/modules/aws_ecs/temporal/roles.tf
+++ b/modules/aws_ecs/temporal/roles.tf
@@ -73,5 +73,5 @@ resource "aws_iam_role" "execution_role" {
 resource "aws_iam_role_policy_attachment" "execution_role" {
   count      = var.launch_type == "FARGATE" ? 1 : 0
   role       = aws_iam_role.execution_role[0].name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+  policy_arn = "arn:${var.iam_partition}:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }

--- a/modules/aws_ecs/temporal/variables.tf
+++ b/modules/aws_ecs/temporal/variables.tf
@@ -210,3 +210,9 @@ variable "service_discovery_namespace" {
   type        = string
   description = "Service discovery namespace DNS name for Retool ECS cluster."
 }
+
+variable "iam_partition" {
+  type        = string
+  description = "AWS Commercial accounts use 'aws'. AWS GovCloud accounts use 'aws-us-gov'"
+  default     = "aws"
+}

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -596,3 +596,9 @@ variable "alb_egress_rules" {
   ]
   description = "Egress rules for load balancer"
 }
+
+variable "iam_partition" {
+  type        = string
+  description = "AWS Commercial accounts use 'aws'. AWS GovCloud accounts use 'aws-us-gov'"
+  default     = "aws"
+}


### PR DESCRIPTION
AWS GovCloud ARNs follow a different format. They begin with "arn:aws-us-gov". AWS Commercial accounts begin with "arn:aws".

This PR works with both AWS GovCloud & Commercial accounts.