### PR TITLE
Add variables to enable RDS backups

### DIFF
--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -42,6 +42,8 @@ resource "aws_db_instance" "this" {
   storage_throughput           = var.rds_storage_throughput
   iops                         = var.rds_iops
   multi_az                     = var.rds_multi_az
+  backup_retention_period      = var.rds_backup_retention_period
+  backup_window                = var.rds_backup_window
 
   skip_final_snapshot = true
   apply_immediately   = true

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -258,6 +258,18 @@ variable "rds_multi_az" {
   description = "Whether the RDS instance should have Multi-AZ enabled. Defaults to false."
 }
 
+variable "rds_backup_retention_period" {
+  type        = number
+  default     = null
+  description = "The number of days to retain backups for. Must be between 0 and 35."
+}
+
+variable "rds_backup_window" {
+  type        = string
+  default     = null
+  description = "The daily time range (in UTC) during which automated backups are created if automated backups are enabled."
+}
+
 variable "use_existing_temporal_cluster" {
   type        = bool
   default     = false

--- a/modules/aws_ecs_ec2/main.tf
+++ b/modules/aws_ecs_ec2/main.tf
@@ -157,6 +157,8 @@ resource "aws_db_instance" "this" {
   vpc_security_group_ids       = [aws_security_group.rds.id]
   performance_insights_enabled = var.rds_performance_insights_enabled
   multi_az                     = var.rds_multi_az
+  backup_retention_period      = var.rds_backup_retention_period
+  backup_window                = var.rds_backup_window
   
   skip_final_snapshot          = true
   apply_immediately           = true

--- a/modules/aws_ecs_ec2/variables.tf
+++ b/modules/aws_ecs_ec2/variables.tf
@@ -121,6 +121,18 @@ variable "rds_multi_az" {
   description = "Whether the RDS instance should have Multi-AZ enabled. Defaults to false."
 }
 
+variable "rds_backup_retention_period" {
+  type        = number
+  default     = null
+  description = "The number of days to retain backups for. Must be between 0 and 35."
+}
+
+variable "rds_backup_window" {
+  type        = string
+  default     = null
+  description = "The daily time range (in UTC) during which automated backups are created if automated backups are enabled."
+}
+
 variable "log_retention_in_days" {
   type        = number
   default     = 14


### PR DESCRIPTION
Adding the `rds_backup_retention_period` and `rds_backup_window` variables to enable RDS backups for the retool database. Defaults to current functionality.