### PR TITLE
Pass secrets to ecs tasks via secrets manager reference

### DIFF
--- a/modules/aws_ecs/locals.tf
+++ b/modules/aws_ecs/locals.tf
@@ -23,10 +23,48 @@ locals {
   // Use var.ecs_telemetry_fluentbit_image if defined, otherwise fallback to the same tag as var.ecs_retool_image
   ecs_telemetry_fluentbit_image = var.ecs_telemetry_fluentbit_image != "" ? var.ecs_telemetry_fluentbit_image : format("%s:%s", "tryretool/retool-aws-for-fluent-bit", split(":", var.ecs_retool_image)[1])
 
+  secret_environment_variables = concat(
+    [
+      {
+        name      = "POSTGRES_USER"
+        valueFrom = aws_secretsmanager_secret.rds_username.arn
+      },
+      {
+        name      = "POSTGRES_PASSWORD"
+        valueFrom = aws_secretsmanager_secret.rds_password.arn
+      },
+      {
+        name      = "JWT_SECRET"
+        valueFrom = aws_secretsmanager_secret.jwt_secret.arn
+      },
+      {
+        name      = "ENCRYPTION_KEY"
+        valueFrom = aws_secretsmanager_secret.encryption_key.arn
+      }
+    ],
+    var.retool_license_key != "" ? [
+      {
+        name      = "LICENSE_KEY"
+        valueFrom = aws_secretsmanager_secret.retool_license_key[0].arn
+      }
+    ] : [],
+    var.temporal_cluster_config.tls_enabled && var.temporal_cluster_config.tls_crt != null ? [
+      {
+        name      = "WORKFLOW_TEMPORAL_TLS_CRT"
+        valueFrom = aws_secretsmanager_secret.temporal_tls_crt[0].arn
+      }
+    ] : [],
+    var.temporal_cluster_config.tls_enabled && var.temporal_cluster_config.tls_key != null ? [
+      {
+        name      = "WORKFLOW_TEMPORAL_TLS_KEY"
+        valueFrom = aws_secretsmanager_secret.temporal_tls_key[0].arn
+      }
+    ] : []
+  )
+
   environment_variables = concat(
     var.additional_env_vars, # add additional environment variables
     local.base_environment_variables,
-    local.temporal_mtls_config,
     var.code_executor_enabled ? [
       {
         name  = "CODE_EXECUTOR_INGRESS_DOMAIN"
@@ -67,26 +105,6 @@ locals {
       {
         name  = "POSTGRES_PORT"
         value = "5432"
-      },
-      {
-        "name"  = "POSTGRES_USER",
-        "value" = var.rds_username
-      },
-      {
-        "name"  = "POSTGRES_PASSWORD",
-        "value" = random_string.rds_password.result
-      },
-      {
-        "name" : "JWT_SECRET",
-        "value" : random_string.jwt_secret.result
-      },
-      {
-        "name" : "ENCRYPTION_KEY",
-        "value" : random_string.encryption_key.result
-      },
-      {
-        "name" : "LICENSE_KEY",
-        "value" : var.retool_license_key
       },
       # Workflows-specific
       {
@@ -170,20 +188,5 @@ locals {
         ]
       }
     ] : []
-  )
-
-  temporal_mtls_config = (
-    var.temporal_cluster_config.tls_enabled && var.temporal_cluster_config.tls_crt != null && var.temporal_cluster_config.tls_key != null ?
-    [
-      {
-        "name" : "WORKFLOW_TEMPORAL_TLS_CRT",
-        "value" : var.temporal_cluster_config.tls_crt
-      },
-      {
-        "name" : "WORKFLOW_TEMPORAL_TLS_KEY",
-        "value" : var.temporal_cluster_config.tls_key
-      }
-    ] :
-    []
   )
 }

--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -278,7 +278,8 @@ resource "aws_ecs_task_definition" "retool_jobs_runner" {
               value = "JOBS_RUNNER"
             }
           ]
-        )
+        ),
+        secrets = local.secret_environment_variables
       }
     ]
   ))
@@ -328,7 +329,8 @@ resource "aws_ecs_task_definition" "retool" {
               "value" = tostring(var.cookie_insecure)
             }
           ]
-        )
+        ),
+        secrets = local.secret_environment_variables
       }
     ]
   ))
@@ -379,7 +381,8 @@ resource "aws_ecs_task_definition" "retool_workflows_backend" {
               "value" = tostring(var.cookie_insecure)
             }
           ]
-        )
+        ),
+        secrets = local.secret_environment_variables
       }
     ]
   ))
@@ -434,7 +437,8 @@ resource "aws_ecs_task_definition" "retool_workflows_worker" {
               "value" = tostring(var.cookie_insecure)
             }
           ]
-        )
+        ),
+        secrets = local.secret_environment_variables
       }
     ]
   ))
@@ -580,7 +584,8 @@ resource "aws_ecs_task_definition" "retool_telemetry" {
               value = base64encode(file(var.telemetry_custom_config_path))
             }
           ] : []
-        )
+        ),
+        secrets = local.secret_environment_variables
       }
     ]
   )

--- a/modules/aws_ecs/roles.tf
+++ b/modules/aws_ecs/roles.tf
@@ -93,6 +93,28 @@ resource "aws_iam_role_policy_attachment" "execution_role" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
+data "aws_iam_policy_document" "execution_role_secrets_policy" {
+  count = var.launch_type == "FARGATE" ? 1 : 0
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+    resources = [for secret in local.secret_environment_variables : secret.valueFrom]
+  }
+}
+
+resource "aws_iam_policy" "execution_role_secrets_policy" {
+  count  = var.launch_type == "FARGATE" ? 1 : 0
+  name   = "${var.deployment_name}-execution-role-secrets-policy"
+  policy = data.aws_iam_policy_document.execution_role_secrets_policy[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "execution_role_secrets" {
+  count      = var.launch_type == "FARGATE" ? 1 : 0
+  role       = aws_iam_role.execution_role[0].name
+  policy_arn = aws_iam_policy.execution_role_secrets_policy[0].arn
+}
+
 # IAM Role for EC2 instances
 resource "aws_iam_instance_profile" "ec2" {
   count = var.launch_type == "EC2" ? 1 : 0

--- a/modules/aws_ecs/secrets.tf
+++ b/modules/aws_ecs/secrets.tf
@@ -57,3 +57,40 @@ resource "aws_secretsmanager_secret_version" "encryption_key" {
   secret_id     = aws_secretsmanager_secret.encryption_key.id
   secret_string = random_string.encryption_key.result
 }
+
+resource "aws_secretsmanager_secret" "retool_license_key" {
+  count                   = var.retool_license_key != "" ? 1 : 0
+  name                    = "${var.deployment_name}-retool-license-key"
+  description             = "This is the Retool license key"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "retool_license_key" {
+  count         = var.retool_license_key != "" ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.retool_license_key[0].id
+  secret_string = var.retool_license_key
+}
+
+resource "aws_secretsmanager_secret" "temporal_tls_crt" {
+  count       = var.temporal_cluster_config.tls_enabled && var.temporal_cluster_config.tls_crt != null ? 1 : 0
+  name        = "${var.deployment_name}-temporal-tls-crt"
+  description = "Temporal client certificate"
+}
+
+resource "aws_secretsmanager_secret_version" "temporal_tls_crt" {
+  count         = var.temporal_cluster_config.tls_enabled && var.temporal_cluster_config.tls_crt != null ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.temporal_tls_crt[0].id
+  secret_string = var.temporal_cluster_config.tls_crt
+}
+
+resource "aws_secretsmanager_secret" "temporal_tls_key" {
+  count       = var.temporal_cluster_config.tls_enabled && var.temporal_cluster_config.tls_key != null ? 1 : 0
+  name        = "${var.deployment_name}-temporal-tls-key"
+  description = "Temporal client key"
+}
+
+resource "aws_secretsmanager_secret_version" "temporal_tls_key" {
+  count         = var.temporal_cluster_config.tls_enabled && var.temporal_cluster_config.tls_key != null ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.temporal_tls_key[0].id
+  secret_string = var.temporal_cluster_config.tls_key
+}

--- a/modules/aws_ecs/temporal/locals.tf
+++ b/modules/aws_ecs/temporal/locals.tf
@@ -23,14 +23,6 @@ locals {
         "value": tostring(module.temporal_aurora_rds.cluster_port)
       },
       {
-        "name": "POSTGRES_USER",
-        "value": var.temporal_aurora_username
-      },
-      {
-        "name": "POSTGRES_PASSWORD",
-        "value": random_string.temporal_aurora_password.result
-      },
-      {
         "name": "DBNAME",
         "value": "temporal"
       },

--- a/modules/aws_ecs/temporal/main.tf
+++ b/modules/aws_ecs/temporal/main.tf
@@ -153,7 +153,17 @@ resource "aws_ecs_task_definition" "retool_temporal" {
             "value" : "${var.temporal_cluster_config.hostname}.${var.service_discovery_namespace}:${var.temporal_cluster_config.port}"
             }
           ] : []
-        )
+        ),
+        secrets = [
+          {
+            name      = "POSTGRES_USER",
+            valueFrom = aws_secretsmanager_secret.temporal_aurora_username.arn
+          },
+          {
+            name      = "POSTGRES_PASSWORD",
+            valueFrom = aws_secretsmanager_secret.temporal_aurora_password.arn
+          }
+        ]
       }
     ]
   )

--- a/modules/aws_ecs/temporal/roles.tf
+++ b/modules/aws_ecs/temporal/roles.tf
@@ -75,3 +75,30 @@ resource "aws_iam_role_policy_attachment" "execution_role" {
   role       = aws_iam_role.execution_role[0].name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
+
+data "aws_iam_policy_document" "secrets_manager_access" {
+  count = var.launch_type == "FARGATE" ? 1 : 0
+
+  statement {
+    effect  = "Allow"
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      aws_secretsmanager_secret.temporal_aurora_password.arn,
+      aws_secretsmanager_secret.temporal_aurora_username.arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "secrets_manager_access" {
+  count = var.launch_type == "FARGATE" ? 1 : 0
+
+  name   = "${var.deployment_name}-secrets-manager-access"
+  path   = "/"
+  policy = data.aws_iam_policy_document.secrets_manager_access[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "execution_role_secrets_manager_access" {
+  count      = var.launch_type == "FARGATE" ? 1 : 0
+  role       = aws_iam_role.execution_role[0].name
+  policy_arn = aws_iam_policy.secrets_manager_access[0].arn
+}


### PR DESCRIPTION
To avoid secrets being presented in plain text in the AWS console.