### PR TITLE
Maintenance and various fixes July, 2025

### DIFF
--- a/modules/aws_ecs/loadbalancers.tf
+++ b/modules/aws_ecs/loadbalancers.tf
@@ -58,7 +58,7 @@ resource "aws_lb_target_group" "this" {
   deregistration_delay = 30
   port                 = 3000
   protocol             = "HTTP"
-  target_type          = var.launch_type == "FARGATE" ? "ip" : "instance"
+  target_type          = "ip"
 
   health_check {
     interval            = 61

--- a/modules/aws_ecs/locals.tf
+++ b/modules/aws_ecs/locals.tf
@@ -136,11 +136,12 @@ locals {
   common_containers = (
     var.telemetry_enabled ? [
       {
-        name      = "retool-fluentbit"
-        essential = true
-        image     = var.ecs_telemetry_fluentbit_image
-        cpu       = var.launch_type == "EC2" ? var.ecs_task_resource_map["fluentbit"]["cpu"] : null
-        memory    = var.launch_type == "EC2" ? var.ecs_task_resource_map["fluentbit"]["memory"] : null
+        name                 = "retool-fluentbit"
+        essential            = true
+        image                = var.ecs_telemetry_fluentbit_image
+        cpu                  = var.launch_type == "EC2" ? var.ec2_task_resource_map["fluentbit"]["cpu"] : null
+        memory               = var.launch_type == "EC2" ? var.ec2_task_resource_map["fluentbit"]["memory"] : null
+        memoryReservation    = var.launch_type == "EC2" ? var.ec2_task_resource_map["fluentbit"]["memory"] : null
 
         firelensConfiguration = {
           type    = "fluentbit"

--- a/modules/aws_ecs/locals.tf
+++ b/modules/aws_ecs/locals.tf
@@ -66,18 +66,6 @@ locals {
         "value" = var.rds_username
       },
       {
-        "name"  = "POSTGRES_PASSWORD",
-        "value" = random_string.rds_password.result
-      },
-      {
-        "name" : "JWT_SECRET",
-        "value" : random_string.jwt_secret.result
-      },
-      {
-        "name" : "ENCRYPTION_KEY",
-        "value" : random_string.encryption_key.result
-      },
-      {
         "name" : "LICENSE_KEY",
         "value" : var.retool_license_key
       },
@@ -112,6 +100,24 @@ locals {
       {
         "name" : "WORKFLOW_TEMPORAL_TLS_ENABLED",
         "value" : tostring(var.temporal_cluster_config.tls_enabled)
+      }
+    ]
+  )
+
+  secrets = concat(
+    var.additional_secrets,
+    [
+      {
+        name = "POSTGRES_PASSWORD",
+        valueFrom = aws_secretsmanager_secret.rds_password.arn
+      },
+      {
+        name      = "JWT_SECRET",
+        valueFrom = aws_secretsmanager_secret.jwt_secret.arn
+      },
+      {
+        name    = "ENCRYPTION_KEY",
+        valueFrom   = aws_secretsmanager_secret.encryption_key.arn
       }
     ]
   )

--- a/modules/aws_ecs/locals.tf
+++ b/modules/aws_ecs/locals.tf
@@ -26,13 +26,6 @@ locals {
   environment_variables = concat(
     var.additional_env_vars, # add additional environment variables
     local.base_environment_variables,
-    local.temporal_mtls_config,
-    var.code_executor_enabled ? [
-      {
-        name  = "CODE_EXECUTOR_INGRESS_DOMAIN"
-        value = format("http://code-executor.%s:3004", local.service_discovery_namespace)
-      }
-    ] : [],
     var.telemetry_enabled ? [
       {
         name  = "RTEL_ENABLED"
@@ -88,11 +81,22 @@ locals {
         "name" : "LICENSE_KEY",
         "value" : var.retool_license_key
       },
-      # Workflows-specific
+    # WORKFLOW_BACKEND_HOST and CODE_EXECUTOR_INGRESS_DOMAIN are workflows-specific services
       {
         "name" : "WORKFLOW_BACKEND_HOST",
         "value" : format("http://workflow-backend.%s:3000", local.service_discovery_namespace)
-      },
+      }
+    ],
+        var.code_executor_enabled ? [
+      {
+        name  = "CODE_EXECUTOR_INGRESS_DOMAIN"
+        value = format("http://code-executor.%s:3004", local.service_discovery_namespace)
+      }
+    ] : [],
+    # The section below is only needed if deploying Temporal locally from this template. 
+    # Retool strongly reccommends using the Retool Managed Temporal option instead.
+    local.temporal_mtls_config, 
+    var.use_existing_temporal_cluster ? [] : [
       {
         "name" : "WORKFLOW_TEMPORAL_CLUSTER_NAMESPACE",
         "value" : var.temporal_cluster_config.namespace

--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -211,7 +211,7 @@ resource "aws_ecs_service" "telemetry" {
 resource "aws_ecs_task_definition" "retool_jobs_runner" {
   family                   = "retool-jobs-runner"
   task_role_arn            = aws_iam_role.task_role.arn
-  execution_role_arn       = var.launch_type == "FARGATE" ? aws_iam_role.execution_role[0].arn : null
+  execution_role_arn       = aws_iam_role.execution_role[0].arn
   requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : ["EC2"]
   network_mode             = "awsvpc"
   cpu                      = var.launch_type == "FARGATE" ? var.fargate_task_resource_map["jobs_runner"]["cpu"] : null
@@ -249,6 +249,8 @@ resource "aws_ecs_task_definition" "retool_jobs_runner" {
             }
           ]
         )
+
+        secrets = local.secrets
       }
     ]
   ))
@@ -257,7 +259,7 @@ resource "aws_ecs_task_definition" "retool_jobs_runner" {
 resource "aws_ecs_task_definition" "retool" {
   family                   = "retool"
   task_role_arn            = aws_iam_role.task_role.arn
-  execution_role_arn       = var.launch_type == "FARGATE" ? aws_iam_role.execution_role[0].arn : null
+  execution_role_arn       = aws_iam_role.execution_role[0].arn
   requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : ["EC2"]
   network_mode             = "awsvpc"
   cpu                      = var.launch_type == "FARGATE" ? var.fargate_task_resource_map["main"]["cpu"] : null
@@ -300,6 +302,8 @@ resource "aws_ecs_task_definition" "retool" {
             }
           ]
         )
+
+        secrets = local.secrets
       }
     ]
   ))
@@ -309,7 +313,7 @@ resource "aws_ecs_task_definition" "retool_workflows_backend" {
   count                    = var.workflows_enabled ? 1 : 0
   family                   = "retool-workflows-backend"
   task_role_arn            = aws_iam_role.task_role.arn
-  execution_role_arn       = var.launch_type == "FARGATE" ? aws_iam_role.execution_role[0].arn : null
+  execution_role_arn       = aws_iam_role.execution_role[0].arn
   requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : ["EC2"]
   network_mode             = "awsvpc"
   cpu                      = var.launch_type == "FARGATE" ? var.fargate_task_resource_map["workflows_backend"]["cpu"] : null
@@ -352,6 +356,8 @@ resource "aws_ecs_task_definition" "retool_workflows_backend" {
             }
           ]
         )
+
+        secrets = local.secrets
       }
     ]
   ))
@@ -361,7 +367,7 @@ resource "aws_ecs_task_definition" "retool_workflows_worker" {
   count                    = var.workflows_enabled ? 1 : 0
   family                   = "retool-workflows-worker"
   task_role_arn            = aws_iam_role.task_role.arn
-  execution_role_arn       = var.launch_type == "FARGATE" ? aws_iam_role.execution_role[0].arn : null
+  execution_role_arn       = aws_iam_role.execution_role[0].arn
   requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : ["EC2"]
   network_mode             = "awsvpc"
   cpu                      = var.launch_type == "FARGATE" ? var.fargate_task_resource_map["code_executor"]["cpu"] : null
@@ -408,6 +414,8 @@ resource "aws_ecs_task_definition" "retool_workflows_worker" {
             }
           ]
         )
+
+        secrets = local.secrets
       }
     ]
   ))
@@ -417,7 +425,7 @@ resource "aws_ecs_task_definition" "retool_code_executor" {
   count                    = var.code_executor_enabled ? 1 : 0
   family                   = "retool-code-executor"
   task_role_arn            = aws_iam_role.task_role.arn
-  execution_role_arn       = var.launch_type == "FARGATE" ? aws_iam_role.execution_role[0].arn : null
+  execution_role_arn       = aws_iam_role.execution_role[0].arn
   requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : ["EC2"]
   network_mode             = "awsvpc"
   cpu                      = var.launch_type == "FARGATE" ? var.fargate_task_resource_map["telemetry"]["cpu"] : null
@@ -472,6 +480,8 @@ resource "aws_ecs_task_definition" "retool_code_executor" {
             }
           ] : []
         )
+
+        secrets = local.secrets
       }
     ]
   ))
@@ -481,7 +491,7 @@ resource "aws_ecs_task_definition" "retool_telemetry" {
   count                    = var.telemetry_enabled ? 1 : 0
   family                   = "retool-telemetry"
   task_role_arn            = aws_iam_role.task_role.arn
-  execution_role_arn       = var.launch_type == "FARGATE" ? aws_iam_role.execution_role[0].arn : null
+  execution_role_arn       = aws_iam_role.execution_role[0].arn
   requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : ["EC2"]
   network_mode             = "awsvpc"
   cpu                      = var.launch_type == "FARGATE" ? var.fargate_task_resource_map["telemetry"]["cpu"] : null

--- a/modules/aws_ecs/roles.tf
+++ b/modules/aws_ecs/roles.tf
@@ -86,7 +86,7 @@ resource "aws_iam_role" "execution_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "execution_role" {
-  role       = aws_iam_role.execution_role[0].name
+  role       = aws_iam_role.execution_role.name
   policy_arn = "arn:${var.iam_partition}:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
@@ -113,7 +113,7 @@ resource aws_iam_policy "execution_role_read_secrets" {
 }
 
 resource "aws_iam_role_policy_attachment" "execution_role_read_secrets" {
-  role       = aws_iam_role.execution_role[0].name
+  role       = aws_iam_role.execution_role.name
   policy_arn = aws_iam_policy.execution_role_read_secrets.arn
 }
 

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -514,6 +514,12 @@ variable "additional_env_vars" {
   description = "Additional environment variables (e.g. BASE_DOMAIN)"
 }
 
+variable "additional_secrets" {
+  type        = list(map(string))
+  default     = []
+  description = "Optional additional environment variables set from pre-existing AWS Secrets Manager Secrets."
+}
+
 variable "additional_temporal_env_vars" {
   type        = list(map(string))
   default     = []

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -4,6 +4,11 @@ variable "aws_region" {
   description = "AWS region. Defaults to `us-east-1`"
 }
 
+variable "profile" {
+  type = string
+  description = "Optional AWS CLI Profile."
+}
+
 variable "node_env" {
   type        = string
   default     = "production"
@@ -112,7 +117,7 @@ variable "ec2_task_resource_map" {
     main = {
       cpu               = 2048
       memory            = 4096
-      memoryReservation = 3072
+      memoryReservation = 4096
     },
     jobs_runner = {
       cpu               = 1024
@@ -122,7 +127,7 @@ variable "ec2_task_resource_map" {
     workflows_backend = {
       cpu               = 2048
       memory            = 4096
-      memoryReservation = 3072
+      memoryReservation = 4096
     }
     workflows_worker = {
       cpu               = 1024

--- a/modules/aws_ecs/variables.tf
+++ b/modules/aws_ecs/variables.tf
@@ -45,7 +45,7 @@ variable "max_instance_count" {
 
 variable "min_instance_count" {
   type        = number
-  description = "Min/desired number of EC2 instances. Defaults to 4."
+  description = "Min/desired number of EC2 instances. Defaults to 3."
   default     = 3
 }
 
@@ -97,7 +97,58 @@ variable "ecs_telemetry_fluentbit_image" {
   default     = "tryretool/retool-aws-for-fluent-bit:3.120.0-edge"
 }
 
-variable "ecs_task_resource_map" {
+# ECS treats CPU and Memory differently between EC2 and Fargate launch types. 
+# Retool provides separate sane defaults for both launch types and the template will use the resource map for the configured launch type. 
+# With Fargate, ECS treats CPU and Memory as exact requests, but with EC2, ECS treats CPU as a soft limit, 
+# memory as a hard limit and supports the additional memoryReservation as a soft limit. 
+
+variable "ec2_task_resource_map" {
+  type = map(object({
+    cpu               = number
+    memory            = number
+    memoryReservation = number
+  }))
+  default = {
+    main = {
+      cpu               = 2048
+      memory            = 4096
+      memoryReservation = 3072
+    },
+    jobs_runner = {
+      cpu               = 1024
+      memory            = 4096
+      memoryReservation = 2048
+    },
+    workflows_backend = {
+      cpu               = 2048
+      memory            = 4096
+      memoryReservation = 3072
+    }
+    workflows_worker = {
+      cpu               = 1024
+      memory            = 4096
+      memoryReservation = 2048
+    }
+    code_executor = {
+      cpu               = 1024
+      memory            = 4096
+      memoryReservation = 2048
+    }
+    telemetry = {
+      cpu               = 1024
+      memory            = 4096
+      memoryReservation = 2048
+    }
+    fluentbit = {
+      cpu               = 512
+      memory            = 2048
+      memoryReservation = 1024
+    }
+  }
+  description = "Amount of CPU and Memory provisioned for each task with EC2 launch type set."
+}
+
+variable "fargate_task_resource_map" {
   type = map(object({
     cpu    = number
     memory = number
@@ -108,8 +159,8 @@ variable "ecs_task_resource_map" {
       memory = 4096
     },
     jobs_runner = {
-      cpu    = 1024
-      memory = 2048
+      cpu    = 2048
+      memory = 4096
     },
     workflows_backend = {
       cpu    = 2048
@@ -132,7 +183,7 @@ variable "ecs_task_resource_map" {
       memory = 1024
     }
   }
-  description = "Amount of CPU and Memory provisioned for each task."
+  description = "Amount of CPU and Memory provisioned for each task with Fargate launch type."
 }
 
 variable "temporal_ecs_task_resource_map" {
@@ -449,6 +500,12 @@ variable "autoscaling_memory_reservation_target" {
   type        = number
   default     = 70.0
   description = "Memory reservation target for the Autoscaling Group. Defaults to 70.0."
+}
+
+variable "autoscaling_cpu_reservation_target" {
+  type        = number
+  default     = 60.0
+  description = "Memory reservation target for the Autoscaling Group. Defaults to 60.0."
 }
 
 variable "additional_env_vars" {


### PR DESCRIPTION
This PR resolves various issues with this ECS Template

- [x] Migrate template from deprecated `aws_launch_configuration` to `aws_launch_template`. Credit to @marks for this change ([AWS docs on deprecation](https://docs.aws.amazon.com/autoscaling/ec2/userguide/migrate-to-launch-templates.html)) ([5b5f34](https://github.com/tryretool/terraform-retool-modules/commit/5b5f342918cc2db01de6aeec0aaf8e73acdf3b96))

- [x] Migrate EC2 launch type from `network_mode=bridge` to `network_mode=awsvpc`. Resolves issues with  `network_mode=bridge`, establishes consistency with [Cloudformation template](https://github.com/tryretool/retool-onpremise/blob/master/cloudformation/retool-workflows.ec2.yaml) and simplifies template. Credit to @marks for this change ([ee7444](https://github.com/tryretool/terraform-retool-modules/commit/ee7444e2bacee243143b976d18c137a09c72cf8f))

- [x] Updates the template to set sane cpu and memory defaults for both the EC2 and Fargate launch types. Replaces non-functional cluster autoscaling policy with a dual-metric (cpu & memory) autoscaling policy to scale tasks (with a TargetTrackingScaling policy_type) and managed scaling of the EC2 instances ([0895fe](https://github.com/tryretool/terraform-retool-modules/commit/0895fefe62c87a37fc37eb8716904e9bb710f8d5))

- [x] Correct environment variables logic to set environment variables required for [local Temporal deploy](https://docs.retool.com/self-hosted/concepts/temporal?temporal=local) on other services only when deploying Temporal locally ([8562d0](https://github.com/tryretool/terraform-retool-modules/commit/8562d06b4863c18c0fdc3553c4ba624a0db6af3d))

- [x] Update template to support setting environment variables from AWS Secrets Manager. The functionally necessary variables—`POSTGRES_PASSWORD`, `JWT_SECRET`,`ENCRYPTION_KEY`—will now be set on tasks using secrets from values stored in AWS Secrets Manager. The template now supports setting additional optional environment variables similarly with `var.additional_secrets` ([9b8841](https://github.com/tryretool/terraform-retool-modules/commit/9b884180ce8fc2cbc8582e50e4d4e558c3697f8a))

- [x] Corrections to above changes ([a3ca3b](https://github.com/tryretool/terraform-retool-modules/commit/a3ca3b1e0764a9acc54d736e2583e4ecc6a9104c))

Successfully manually deployed with the following configuration with both `launch_type = "FARGATE"` & `launch_type = "EC2"`:

```
aws_region = "<region>"
profile = "<profile>"
private_subnet_ids = [<Private Subnet #1 in AZ a>, <Private Subnet #2 in AZ b>]
public_subnet_ids = [<Public Subnet #1 in AZ a>, <Public Subnet #1 in AZ b>]
ssh_key_name = "<ssh key>"
instance_type = "t3.xlarge"
min_instance_count = 5
max_instance_count = 10
maximum_percent = 150
minimum_healthy_percent = 50
retool_license_key = "<license key>"
ecs_retool_image = "tryretool/backend:3.196.9-stable"
ecs_code_executor_image = "tryretool/code-executor-service:3.196.9-stable"
rds_instance_class = "db.t3.micro"
rds_storage_type = "gp3"
rds_allocated_storage = 20
vpc_id = "<vpc-d>"
launch_type = "FARGATE" | "EC2"
workflows_enabled = true
use_existing_temporal_cluster = true
code_executor_enabled = true
telemetry_enabled = false
additional_env_vars = [
        {
            name = "BASE_DOMAIN",
            value = "<base domain>"
        }
    ]
```
