### PR TITLE
ensure code executor uses same version in ec2 standalone TF script

### DIFF
--- a/modules/aws_ec2_standalone/main.tf
+++ b/modules/aws_ec2_standalone/main.tf
@@ -93,7 +93,8 @@ resource "aws_instance" "this" {
   cd retool-onpremise
 
   # Rewrite Dockerfile
-  echo FROM tryretool/backend:${var.version_number} > Dockerfile
+  echo FROM tryretool/code-executor-service:${var.version_number} AS code-executor > Dockerfile
+  echo FROM tryretool/backend:${var.version_number} >> Dockerfile
   echo CMD ./docker_scripts/start_api.sh >> Dockerfile
 
   # Initialize Docker and Retool Installation


### PR DESCRIPTION
[retool-onpremise already handles CE mismatches](https://github.com/tryretool/retool-onpremise/blob/master/Dockerfile) so let's just make sure we have the same setup for our ec2 standalone terraform script