### PR TITLE
fix: relax aws provider constraints

### DIFF
--- a/modules/aws_ecs/main.tf
+++ b/modules/aws_ecs/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/modules/aws_ecs_ec2/main.tf
+++ b/modules/aws_ecs_ec2/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 4.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
    
Relax AWS provider version constraints from pessimistic (~>) to minimum (>=) in aws_ecs and aws_ecs_ec2 modules

## Reasoning

Reusable modules should only constrain their minimum allowed provider version (e.g. >= 5.0)  rather than using pessimistic locking (~> 5.0). This avoids known incompatibilities while giving module consumers the flexibility to upgrade to newer provider versions without needing to modify the module.

At the moment, we are unable to use this module while using the newer AWS Provider v6

Reference: https://developer.hashicorp.com/terraform/language/providers/requirements#best-practices-for-provider-versions
